### PR TITLE
refactor: sync collection property filters between mobile (slider) and desktop (inline)

### DIFF
--- a/resources/js/Pages/Collections/Components/CollectionFilterSlider/CollectionFilterSlider.tsx
+++ b/resources/js/Pages/Collections/Components/CollectionFilterSlider/CollectionFilterSlider.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/Components/Buttons";
 import { Slider } from "@/Components/Slider";
@@ -39,6 +39,10 @@ export const CollectionFilterSlider = ({
     const selectedTraitsChangedHandler = (groupName: string, value: string, displayType: string): void => {
         setSelectedTraits((previous) => selectedTraitsSetHandler(previous, groupName, value, displayType));
     };
+
+    useEffect(() => {
+        setSelectedTraits(defaultSelectedTraits);
+    }, [defaultSelectedTraits]);
 
     const resetFilters = (): void => {
         setShowOnlyOwned(defaultShowOnlyOwned);

--- a/resources/js/Pages/Collections/Components/CollectionPropertiesFilter/CollectionPropertiesFilter.blocks.tsx
+++ b/resources/js/Pages/Collections/Components/CollectionPropertiesFilter/CollectionPropertiesFilter.blocks.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { EmptyBlock } from "@/Components/EmptyBlock/EmptyBlock";
 import { Checkbox } from "@/Components/Form/Checkbox";
@@ -23,6 +23,12 @@ const CollectionPropertiesFilterItem = ({
     initiallyExpanded?: boolean;
 }): JSX.Element => {
     const [expanded, setExpanded] = useState(initiallyExpanded);
+
+    useEffect(() => {
+        if (initiallyExpanded) {
+            setExpanded(initiallyExpanded);
+        }
+    }, [initiallyExpanded]);
 
     return (
         <div className="flex flex-col border-t border-theme-secondary-300 px-6 py-4">


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/861n9qwry

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
