### PR TITLE
fix: ignore watch pattern on pnpm build

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -34,10 +34,12 @@ export default defineConfig({
             input: "resources/js/app.tsx",
             refresh: true,
         }),
-        watch({
-            pattern: "app/{Data,Enums}/**/*.php",
-            command: "npm run generate:typescript",
-        }),
+        process.env.NODE_ENV !== "production"
+            ? watch({
+                  pattern: "app/{Data,Enums}/**/*.php",
+                  command: "npm run generate:typescript",
+              })
+            : null,
         react(),
         svgr(),
         markdown(),


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/861na8a4k

It now checks for `NODE_ENV`, which will be `production` when `pnpm build` is called (it's `development` for `pnpm dev`)

This means that any build call will ignore the watcher, which should be ok as we run `pnpm dev` during development and that's when files may change, so it shouldn't affect any regular building scenarios. Open to insights from others though

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
