### PR TITLE
fix: incorrect nft being reported

### DIFF
--- a/resources/js/Components/Collections/Nfts/NftReportModal/NftReportModal.tsx
+++ b/resources/js/Components/Collections/Nfts/NftReportModal/NftReportModal.tsx
@@ -28,7 +28,7 @@ export const NftReportModal = ({ nft, reportReasons, isOpen, onClose }: Properti
 
     const submit = (): void => {
         setFailed(false);
-        post(route("nft-reports.create", { nft: nft.tokenNumber }), {
+        post(route("nft-reports.create", { nft: nft.id }), {
             preserveState: true,
             preserveScroll: true,
             onSuccess: close,

--- a/routes/web.php
+++ b/routes/web.php
@@ -56,7 +56,7 @@ Route::middleware('auth')->group(function () {
     });
 
     Route::group(['prefix' => 'nfts'], function () {
-        Route::post('{nft:token_number}/reports', [NftReportController::class, 'store'])->name('nft-reports.create')->middleware('throttle:nft:reports');
+        Route::post('{nft:id}/reports', [NftReportController::class, 'store'])->name('nft-reports.create')->middleware('throttle:nft:reports');
     });
 
     Route::group(['prefix' => 'galleries', 'middleware' => 'features:galleries'], function () {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[report] filament links to incorrect nft via report](https://app.clickup.com/t/862kcgz6a)

## Summary

- When users reported an NFT, we were using the `tokenNumber` of an NFT, which sometimes was duplicated and caused the admin to go to a different NFT to see the report.
- To solve this, we're now using the NFT `id` property.

## Steps to reproduce

1. Follow the steps in the video to see the magic 🌟 

https://github.com/ArdentHQ/dashbrd/assets/55117912/a652c9c8-1014-4c89-adf3-bddc889e834e



## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
