### PR TITLE
fix: flaky test, collections with minted_date

### DIFF
--- a/app/Jobs/DetermineCollectionMintingDate.php
+++ b/app/Jobs/DetermineCollectionMintingDate.php
@@ -30,6 +30,7 @@ class DetermineCollectionMintingDate implements ShouldQueue
         $existing = Collection::query()
                             ->where('network_id', $this->nft->networkId)
                             ->where('minted_block', $this->nft->mintedBlock)
+                            ->whereNotNull('minted_at')
                             ->value('minted_at');
 
         // Check whether we already have a minted timestamp for the collection with the same minting block...


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Closes https://app.clickup.com/t/85ztyf16c

Issue was because the test uses two collections, the one without minted date and another with minted date, the query used to search for a collection and sometimes it returned the one that it was supposed to be updated (probably because both have the same created date, adding an extra query param solved the issue and the potential logic error


## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
