### PR TITLE
chore: disable views, gate and livewire tabs for debugbar

### DIFF
--- a/config/debugbar.php
+++ b/config/debugbar.php
@@ -158,10 +158,10 @@ return [
         'exceptions' => true,  // Exception displayer
         'log' => true,  // Logs from Monolog (merged in messages if enabled)
         'db' => true,  // Show database (PDO) queries and bindings
-        'views' => true,  // Views with their data
+        'views' => false,  // Views with their data
         'route' => true,  // Current route information
         'auth' => false, // Display Laravel authentication status
-        'gate' => true,  // Display Laravel Gate checks
+        'gate' => false,  // Display Laravel Gate checks
         'session' => true,  // Display session data
         'symfony_request' => true,  // Only one can be enabled..
         'mail' => true,  // Catch mail messages
@@ -173,7 +173,7 @@ return [
         'config' => false, // Display config settings
         'cache' => false, // Display cache events
         'models' => true,  // Display models
-        'livewire' => true,  // Display Livewire (when available)
+        'livewire' => false,  // Display Livewire (when available)
     ],
 
     /*


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Views is mostly irrelevant as we use Inertia and React. Gates we don't use except for the admin panel. Livewire we don't use.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
