### PR TITLE
chore: replace the old primary color scheme

### DIFF
--- a/resources/css/_buttons.css
+++ b/resources/css/_buttons.css
@@ -1,21 +1,21 @@
 @layer components {
     .button-primary,
     .button-icon-primary {
-        @apply transition-default inline-flex items-center rounded-3xl bg-theme-hint-600 px-5 py-2 font-medium text-white outline-none outline-3 outline-offset-0 hover:bg-theme-hint-700 focus-visible:bg-theme-hint-600 focus-visible:outline-theme-hint-300 active:bg-theme-hint-800;
+        @apply transition-default inline-flex items-center rounded-3xl bg-theme-primary-600 px-5 py-2 font-medium text-white outline-none outline-3 outline-offset-0 hover:bg-theme-primary-700 focus-visible:bg-theme-primary-600 focus-visible:outline-theme-primary-300 active:bg-theme-primary-800;
     }
 
     .button-bordered {
-        @apply transition-default inline-flex h-10 items-center rounded-3xl border border-theme-secondary-300 bg-white px-5 py-2 font-medium outline-none outline-3 outline-offset-0 hover:bg-theme-secondary-300 focus-visible:outline-theme-hint-300 active:border-theme-secondary-400 active:bg-theme-secondary-400;
+        @apply transition-default inline-flex h-10 items-center rounded-3xl border border-theme-secondary-300 bg-white px-5 py-2 font-medium outline-none outline-3 outline-offset-0 hover:bg-theme-secondary-300 focus-visible:outline-theme-primary-300 active:border-theme-secondary-400 active:bg-theme-secondary-400;
     }
 
     .button-secondary,
     .button-icon-secondary {
-        @apply transition-default inline-flex items-center rounded-3xl bg-theme-secondary-100 px-5 py-2 font-medium outline-none outline-3 outline-offset-0 hover:bg-theme-secondary-300 focus-visible:bg-theme-secondary-300 focus-visible:outline-theme-hint-300 active:bg-theme-secondary-400;
+        @apply transition-default inline-flex items-center rounded-3xl bg-theme-secondary-100 px-5 py-2 font-medium outline-none outline-3 outline-offset-0 hover:bg-theme-secondary-300 focus-visible:bg-theme-secondary-300 focus-visible:outline-theme-primary-300 active:bg-theme-secondary-400;
     }
 
     .button-danger,
     .button-icon-danger {
-        @apply transition-default inline-flex items-center rounded-3xl bg-theme-danger-400 px-5 py-2 font-medium text-white outline-none outline-3 outline-offset-0 hover:bg-theme-danger-600 focus-visible:bg-theme-danger-400 focus-visible:outline-theme-hint-300 active:bg-theme-danger-700;
+        @apply transition-default inline-flex items-center rounded-3xl bg-theme-danger-400 px-5 py-2 font-medium text-white outline-none outline-3 outline-offset-0 hover:bg-theme-danger-600 focus-visible:bg-theme-danger-400 focus-visible:outline-theme-primary-300 active:bg-theme-danger-700;
     }
 
     .button-icon {
@@ -23,11 +23,11 @@
     }
 
     .button-icon-primary {
-        @apply inline-flex h-10 w-10 items-center justify-center rounded-full border border-theme-hint-600 bg-theme-hint-600 p-0;
+        @apply inline-flex h-10 w-10 items-center justify-center rounded-full border border-theme-primary-600 bg-theme-primary-600 p-0;
     }
 
     .button-icon-secondary {
-        @apply inline-flex h-10 w-10 items-center justify-center rounded-full bg-theme-secondary-100 p-0 text-theme-hint-900;
+        @apply inline-flex h-10 w-10 items-center justify-center rounded-full bg-theme-secondary-100 p-0 text-theme-primary-900;
     }
 
     .button-icon-danger {
@@ -40,7 +40,7 @@
 
     .button-secondary,
     .button-icon {
-        @apply transition-default inline-flex items-center text-theme-hint-900 outline-none outline-3 outline-offset-0 hover:bg-theme-secondary-300 focus-visible:outline-theme-hint-300 active:border-theme-secondary-400 active:bg-theme-secondary-400;
+        @apply transition-default inline-flex items-center text-theme-primary-900 outline-none outline-3 outline-offset-0 hover:bg-theme-secondary-300 focus-visible:outline-theme-primary-300 active:border-theme-secondary-400 active:bg-theme-secondary-400;
     }
 
     .button-primary[disabled],
@@ -81,7 +81,7 @@
         @apply hover:border-theme-danger-100 hover:bg-theme-danger-100 hover:text-theme-danger-400 active:border-theme-danger-200 active:bg-theme-danger-200;
     }
     .button-like:not(.button-like-selected) svg path {
-        @apply fill-transparent stroke-theme-hint-900;
+        @apply fill-transparent stroke-theme-primary-900;
     }
     .button-like:not(.button-like-selected):not([disabled]):hover svg path {
         @apply stroke-theme-danger-400;
@@ -96,23 +96,23 @@
 
     /* Save */
     .button-save:not([disabled]) {
-        @apply hover:border-theme-hint-100 hover:bg-theme-hint-100 hover:text-theme-hint-600 active:border-theme-secondary-400 active:bg-theme-secondary-400;
+        @apply hover:border-theme-primary-100 hover:bg-theme-primary-100 hover:text-theme-primary-600 active:border-theme-secondary-400 active:bg-theme-secondary-400;
     }
     .button-save:not(.button-save-selected) svg path {
-        @apply fill-transparent stroke-theme-hint-900;
+        @apply fill-transparent stroke-theme-primary-900;
     }
     .button-save:not(.button-save-selected):not([disabled]):hover svg path {
-        @apply stroke-theme-hint-600;
+        @apply stroke-theme-primary-600;
     }
     .button-save:not([disabled]):active {
         @apply border-theme-secondary-400 bg-theme-secondary-400;
     }
 
     .button-save-selected {
-        @apply border-theme-hint-100 bg-theme-hint-50 text-theme-hint-600;
+        @apply border-theme-primary-100 bg-theme-primary-50 text-theme-primary-600;
     }
     .button-save-selected svg path {
-        @apply fill-theme-hint-200 stroke-theme-hint-600;
+        @apply fill-theme-primary-200 stroke-theme-primary-600;
     }
 
     .button-like[disabled] svg path,

--- a/resources/css/_cookies_modal.css
+++ b/resources/css/_cookies_modal.css
@@ -5,15 +5,15 @@
 body {
     --cc-bg: #fff;
     --cc-text: #112954;
-    --cc-btn-primary-bg: theme("colors.theme-hint-700");
+    --cc-btn-primary-bg: theme("colors.theme-primary-700");
     --cc-btn-primary-text: var(--cc-bg);
     --cc-font-family: theme("fontFamily.sans");
-    --cc-btn-primary-hover-bg: theme("colors.theme-hint-800");
+    --cc-btn-primary-hover-bg: theme("colors.theme-primary-800");
     --cc-btn-secondary-bg: theme("colors.theme-secondary-100");
-    --cc-btn-secondary-text: theme("colors.theme-hint-900");
+    --cc-btn-secondary-text: theme("colors.theme-primary-900");
     --cc-btn-secondary-hover-bg: theme("colors.theme-secondary-200");
     --cc-toggle-bg-off: theme("colors.theme-secondary-500");
-    --cc-toggle-bg-on: theme("colors.theme-hint-700");
+    --cc-toggle-bg-on: theme("colors.theme-primary-700");
     --cc-toggle-bg-readonly: theme("colors.theme-secondary-300");
     --cc-toggle-knob-bg: #fff;
     --cc-toggle-knob-icon-color: theme("colors.theme-secondary-300");
@@ -24,7 +24,7 @@ body {
     --cc-cookie-table-border: theme("colors.theme-secondary-300");
     --cc-overlay-bg: theme("colors.theme-secondary-900 / 50%");
     --cc-webkit-scrollbar-bg: theme("colors.theme-secondary-50");
-    --cc-webkit-scrollbar-bg-hover: theme("colors.theme-hint-700");
+    --cc-webkit-scrollbar-bg-hover: theme("colors.theme-primary-700");
 }
 
 body .cc_div .c-bn {

--- a/resources/css/_general.css
+++ b/resources/css/_general.css
@@ -44,11 +44,11 @@ body {
     }
 
     .custom-scroll::-webkit-scrollbar-thumb {
-        @apply rounded-lg bg-theme-hint-200;
+        @apply rounded-lg bg-theme-primary-200;
     }
 
     .custom-scroll {
-        scrollbar-color: rgb(var(--theme-color-hint-200)) transparent;
+        scrollbar-color: rgb(var(--theme-color-primary-200)) transparent;
     }
 }
 

--- a/resources/css/_tables.css
+++ b/resources/css/_tables.css
@@ -72,7 +72,7 @@
 
 .table-list tbody tr:hover::after {
     content: "";
-    @apply outline-theme-hint-100;
+    @apply outline-theme-primary-100;
 }
 
 .table-list tbody tr td:first-child::before {

--- a/resources/css/_variables.css
+++ b/resources/css/_variables.css
@@ -71,6 +71,18 @@
     --theme-color-info-800: 11 77 199; /* #0b4dc7 */
     --theme-color-info-900: 23 62 133; /* #173e85 */
 
+    /* Purple */
+    --theme-color-hint-50: 248 248 255; /* #f8f8ff */
+    --theme-color-hint-100: 229 232 255; /* #e5e8ff */
+    --theme-color-hint-200: 207 212 255; /* #cfd4ff */
+    --theme-color-hint-300: 168 177 255; /* #a8b1ff */
+    --theme-color-hint-400: 134 146 255; /* #8692ff */
+    --theme-color-hint-500: 107 122 255; /* #6b7aff */
+    --theme-color-hint-600: 80 96 238; /* #5060ee */
+    --theme-color-hint-700: 61 76 211; /* #3d4cd3 */
+    --theme-color-hint-800: 44 57 174; /* #2c39ae */
+    --theme-color-hint-900: 33 43 131; /* #212b83 */
+
     /* White */
     --theme-color-white: 255 255 255; /* #ffffff */
 

--- a/resources/css/_variables.css
+++ b/resources/css/_variables.css
@@ -1,16 +1,15 @@
 :root {
-    /* Blue */
-    --theme-color-primary-rgb: 9 100 228; /* #0964E4 */
-    --theme-color-primary-50: 245 250 255; /* #f5faff */
-    --theme-color-primary-100: 229 240 248; /* #e5f0f8 */
-    --theme-color-primary-200: 186 214 240; /* #bad6f0 */
-    --theme-color-primary-300: 153 199 238; /* #99c7ee */
-    --theme-color-primary-400: 119 185 254; /* #77b9fe */
-    --theme-color-primary-500: 62 157 255; /* #3e9dff */
-    --theme-color-primary-600: 0 125 255; /* #007dff */
-    --theme-color-primary-700: 7 90 242; /* #075af2 */
-    --theme-color-primary-800: 11 77 199; /* #0b4dc7 */
-    --theme-color-primary-900: 23 62 133; /* #173e85 */
+    /* Purple */
+    --theme-color-primary-50: 248 248 255; /* #f8f8ff */
+    --theme-color-primary-100: 229 232 255; /* #e5e8ff */
+    --theme-color-primary-200: 207 212 255; /* #cfd4ff */
+    --theme-color-primary-300: 168 177 255; /* #a8b1ff */
+    --theme-color-primary-400: 134 146 255; /* #8692ff */
+    --theme-color-primary-500: 107 122 255; /* #6b7aff */
+    --theme-color-primary-600: 80 96 238; /* #5060ee */
+    --theme-color-primary-700: 61 76 211; /* #3d4cd3 */
+    --theme-color-primary-800: 44 57 174; /* #2c39ae */
+    --theme-color-primary-900: 33 43 131; /* #212b83 */
 
     /* Gray */
     --theme-color-secondary-50: 250 250 255; /* #fafaff */
@@ -71,18 +70,6 @@
     --theme-color-info-700: 7 90 242; /* #075af2 */
     --theme-color-info-800: 11 77 199; /* #0b4dc7 */
     --theme-color-info-900: 23 62 133; /* #173e85 */
-
-    /* Purple */
-    --theme-color-hint-50: 248 248 255; /* #f8f8ff */
-    --theme-color-hint-100: 229 232 255; /* #e5e8ff */
-    --theme-color-hint-200: 207 212 255; /* #cfd4ff */
-    --theme-color-hint-300: 168 177 255; /* #a8b1ff */
-    --theme-color-hint-400: 134 146 255; /* #8692ff */
-    --theme-color-hint-500: 107 122 255; /* #6b7aff */
-    --theme-color-hint-600: 80 96 238; /* #5060ee */
-    --theme-color-hint-700: 61 76 211; /* #3d4cd3 */
-    --theme-color-hint-800: 44 57 174; /* #2c39ae */
-    --theme-color-hint-900: 33 43 131; /* #212b83 */
 
     /* White */
     --theme-color-white: 255 255 255; /* #ffffff */

--- a/resources/js/Components/BalanceHeader/BalanceHeader.skeleton.tsx
+++ b/resources/js/Components/BalanceHeader/BalanceHeader.skeleton.tsx
@@ -163,9 +163,9 @@ export const BalanceHeaderSkeleton = ({ animated }: { animated: boolean }): JSX.
                             <LinkButton
                                 data-testid="BalanceHeader__more-details"
                                 className={cn(
-                                    "transition-default rounded-full text-sm font-medium leading-5.5 text-theme-hint-600 underline decoration-transparent underline-offset-2 outline-none",
-                                    "hover:text-theme-hint-700 hover:decoration-theme-hint-700",
-                                    "outline-offset-4 focus-visible:outline-3 focus-visible:outline-theme-hint-300",
+                                    "transition-default rounded-full text-sm font-medium leading-5.5 text-theme-primary-600 underline decoration-transparent underline-offset-2 outline-none",
+                                    "hover:text-theme-primary-700 hover:decoration-theme-primary-700",
+                                    "outline-offset-4 focus-visible:outline-3 focus-visible:outline-theme-primary-300",
                                 )}
                             >
                                 {t("common.more_details")}

--- a/resources/js/Components/BalanceHeader/BalanceHeader.tsx
+++ b/resources/js/Components/BalanceHeader/BalanceHeader.tsx
@@ -113,11 +113,11 @@ export const BalanceHeader = ({
                                     setBreakdownOpen(true);
                                 }}
                                 className={cn(
-                                    "transition-default rounded-full text-sm font-medium leading-5.5 text-theme-hint-600",
+                                    "transition-default rounded-full text-sm font-medium leading-5.5 text-theme-primary-600",
                                     "underline decoration-transparent underline-offset-2",
                                     "outline-none outline-3 outline-offset-4",
-                                    "hover:text-theme-hint-700 hover:decoration-theme-hint-700",
-                                    "focus-visible:outline-theme-hint-300",
+                                    "hover:text-theme-primary-700 hover:decoration-theme-primary-700",
+                                    "focus-visible:outline-theme-primary-300",
                                 )}
                             >
                                 {t("common.more_details")}

--- a/resources/js/Components/BalanceHeader/BalanceHeaderMobile.skeleton.tsx
+++ b/resources/js/Components/BalanceHeader/BalanceHeaderMobile.skeleton.tsx
@@ -83,9 +83,9 @@ export const BalanceHeaderMobileSkeleton = ({ animated }: { animated: boolean })
                     <LinkButton
                         data-testid="BalanceHeaderMobile__more-details"
                         className={cn(
-                            "transition-default rounded-sm border-b border-transparent text-sm font-medium leading-none text-theme-hint-600 outline-none ",
-                            "hover:border-theme-hint-700 hover:text-theme-hint-700",
-                            "focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-theme-hint-300 focus-visible:ring-offset-2",
+                            "transition-default rounded-sm border-b border-transparent text-sm font-medium leading-none text-theme-primary-600 outline-none ",
+                            "hover:border-theme-primary-700 hover:text-theme-primary-700",
+                            "focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-theme-primary-300 focus-visible:ring-offset-2",
                         )}
                     >
                         {t("common.more_details")}

--- a/resources/js/Components/BalanceHeader/BalanceHeaderMobile.tsx
+++ b/resources/js/Components/BalanceHeader/BalanceHeaderMobile.tsx
@@ -45,7 +45,7 @@ export const BalanceHeaderMobile = ({
                     <Clipboard text={address}>
                         <button type="button">
                             <Icon
-                                className="text-theme-hint-600"
+                                className="text-theme-primary-600"
                                 name="Copy"
                                 size="md"
                             />
@@ -86,9 +86,9 @@ export const BalanceHeaderMobile = ({
                             setBreakdownOpen(true);
                         }}
                         className={cn(
-                            "transition-default rounded-sm border-b border-transparent text-sm font-medium leading-none text-theme-hint-600 outline-none ",
-                            "hover:border-theme-hint-700 hover:text-theme-hint-700",
-                            "focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-theme-hint-300 focus-visible:ring-offset-2",
+                            "transition-default rounded-sm border-b border-transparent text-sm font-medium leading-none text-theme-primary-600 outline-none ",
+                            "hover:border-theme-primary-700 hover:text-theme-primary-700",
+                            "focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-theme-primary-300 focus-visible:ring-offset-2",
                         )}
                     >
                         {t("common.more_details")}

--- a/resources/js/Components/Buttons/LikeButton.tsx
+++ b/resources/js/Components/Buttons/LikeButton.tsx
@@ -8,7 +8,7 @@ export const LikeButton = ({ children, className, ...properties }: LikeButtonPro
         variant="bordered"
         className={cn(className, "button-like")}
         {...properties}
-        iconClass="text-theme-hint-900"
+        iconClass="text-theme-primary-900"
     >
         <span className="text-sm font-medium text-theme-secondary-700">{children}</span>
     </Button>

--- a/resources/js/Components/Carousel/Carousel.tsx
+++ b/resources/js/Components/Carousel/Carousel.tsx
@@ -42,7 +42,7 @@ export const CarouselControls = ({
         >
             <div className="flex items-center">
                 <Link
-                    className="ml-2 text-theme-hint-600 sm:hidden"
+                    className="ml-2 text-theme-primary-600 sm:hidden"
                     href={viewAllPath}
                 >
                     <Icon name="ArrowRight" />

--- a/resources/js/Components/Clipboard/Clipboard.tsx
+++ b/resources/js/Components/Clipboard/Clipboard.tsx
@@ -92,10 +92,10 @@ export const ClipboardButton = ({ text, className, zIndex }: ClipboardProperties
     >
         <button
             type="button"
-            className="transition-default rounded-full outline-none outline-3 outline-offset-8 focus-visible:outline-theme-hint-300"
+            className="transition-default rounded-full outline-none outline-3 outline-offset-8 focus-visible:outline-theme-primary-300"
         >
             <Icon
-                className="text-theme-hint-600 transition-colors hover:text-theme-hint-700"
+                className="text-theme-primary-600 transition-colors hover:text-theme-primary-700"
                 name="Copy"
                 size="md"
             />

--- a/resources/js/Components/Collections/CollectionActions/CollectionActions.tsx
+++ b/resources/js/Components/Collections/CollectionActions/CollectionActions.tsx
@@ -12,7 +12,7 @@ interface ActionProperties extends Omit<React.HTMLProps<HTMLButtonElement>, "typ
 const Action = ({ ...properties }: ActionProperties): JSX.Element => (
     <button
         type="button"
-        className="transition-default block w-full whitespace-nowrap rounded-sm px-6 py-2.5 text-left text-base font-medium text-theme-secondary-700 outline-none outline-3 outline-offset-[-3px]  focus-visible:outline-theme-hint-300 enabled:cursor-pointer enabled:hover:bg-theme-secondary-100 enabled:hover:text-theme-secondary-900 disabled:text-theme-secondary-500"
+        className="transition-default block w-full whitespace-nowrap rounded-sm px-6 py-2.5 text-left text-base font-medium text-theme-secondary-700 outline-none outline-3 outline-offset-[-3px]  focus-visible:outline-theme-primary-300 enabled:cursor-pointer enabled:hover:bg-theme-secondary-100 enabled:hover:text-theme-secondary-900 disabled:text-theme-secondary-500"
         {...properties}
     />
 );

--- a/resources/js/Components/Collections/CollectionActivityTable/CollectionActivityTable.blocks.tsx
+++ b/resources/js/Components/Collections/CollectionActivityTable/CollectionActivityTable.blocks.tsx
@@ -46,7 +46,7 @@ export const AddressLink = ({
             <Link
                 variant="link"
                 fontSize="text-sm sm:text-base"
-                textColor="text-theme-hint-600"
+                textColor="text-theme-primary-600"
                 className="flex items-center"
                 href={addressUrl(address)}
                 external
@@ -90,7 +90,7 @@ export const Name = ({
             />
         </div>
 
-        <span className="transition-default truncate text-base font-medium leading-5.5 text-theme-hint-600 underline decoration-transparent underline-offset-2 outline-none outline-3 outline-offset-4 hover:text-theme-hint-700 hover:decoration-theme-hint-700 focus-visible:outline-theme-hint-300 md:max-w-[8.125rem] lg:max-w-[16.875rem] xl:max-w-[25rem]">
+        <span className="transition-default truncate text-base font-medium leading-5.5 text-theme-primary-600 underline decoration-transparent underline-offset-2 outline-none outline-3 outline-offset-4 hover:text-theme-primary-700 hover:decoration-theme-primary-700 focus-visible:outline-theme-primary-300 md:max-w-[8.125rem] lg:max-w-[16.875rem] xl:max-w-[25rem]">
             {activity.nft.name}
         </span>
     </div>
@@ -113,7 +113,7 @@ export const NameMobile = ({
                 }),
             );
         }}
-        className="transition-default cursor-pointer truncate font-medium leading-5.5 text-theme-hint-600 underline decoration-transparent underline-offset-2 outline-none outline-3 outline-offset-4 hover:text-theme-hint-700 hover:decoration-theme-hint-700 focus-visible:outline-theme-hint-300"
+        className="transition-default cursor-pointer truncate font-medium leading-5.5 text-theme-primary-600 underline decoration-transparent underline-offset-2 outline-none outline-3 outline-offset-4 hover:text-theme-primary-700 hover:decoration-theme-primary-700 focus-visible:outline-theme-primary-300"
     >
         {activity.nft.name}
     </span>
@@ -217,7 +217,7 @@ export const Type = ({
                                 variant="link"
                                 className="flex items-center leading-6"
                                 fontSize="text-base"
-                                textColor="text-theme-hint-600"
+                                textColor="text-theme-primary-600"
                                 href={transactionUrl(activity.id)}
                                 external
                                 iconClassName="ml-2 text-theme-secondary-500"
@@ -276,7 +276,7 @@ export const Type = ({
         <div className="flex items-center space-x-2">
             <Link
                 variant="link"
-                textColor="text-theme-hint-600"
+                textColor="text-theme-primary-600"
                 href={transactionUrl(activity.id)}
                 className="flex items-center"
                 external
@@ -287,7 +287,7 @@ export const Type = ({
 
             <Icon
                 name={activityIcon}
-                className="text-theme-hint-600"
+                className="text-theme-primary-600"
                 size="lg"
             />
         </div>

--- a/resources/js/Components/Collections/CollectionCard/CollectionCard.tsx
+++ b/resources/js/Components/Collections/CollectionCard/CollectionCard.tsx
@@ -58,7 +58,7 @@ export const CollectionCard = ({
         <div
             ref={reference}
             data-testid="CollectionCard"
-            className="transition-default group relative flex cursor-pointer flex-col rounded-xl border border-theme-secondary-300 p-8 outline outline-3 outline-transparent hover:outline-theme-hint-100 focus-visible:outline-theme-hint-300"
+            className="transition-default group relative flex cursor-pointer flex-col rounded-xl border border-theme-secondary-300 p-8 outline outline-3 outline-transparent hover:outline-theme-primary-100 focus-visible:outline-theme-primary-300"
             onClick={() => {
                 router.visit(
                     route("collections.view", {
@@ -105,7 +105,7 @@ export const CollectionCard = ({
             >
                 <span
                     ref={collectionNameReference}
-                    className="break-word-legacy group-hover mx-auto mt-1 max-w-full truncate text-lg font-medium leading-7 group-hover:text-theme-hint-700"
+                    className="break-word-legacy group-hover mx-auto mt-1 max-w-full truncate text-lg font-medium leading-7 group-hover:text-theme-primary-700"
                 >
                     {collection.name}
                 </span>

--- a/resources/js/Components/Collections/CollectionCard/CollectionCardSkeleton.tsx
+++ b/resources/js/Components/Collections/CollectionCard/CollectionCardSkeleton.tsx
@@ -7,7 +7,7 @@ export const CollectionCardSkeleton = (): JSX.Element => {
     return (
         <div
             data-testid="CollectionCard"
-            className="transition-default relative flex flex-col rounded-xl border border-theme-secondary-300 p-8 outline outline-3 outline-transparent hover:outline-theme-hint-100 focus-visible:outline-theme-hint-300"
+            className="transition-default relative flex flex-col rounded-xl border border-theme-secondary-300 p-8 outline outline-3 outline-transparent hover:outline-theme-primary-100 focus-visible:outline-theme-primary-300"
         >
             <div className="aspect-[3/2] w-full rounded-lg">
                 <div

--- a/resources/js/Components/Collections/CollectionDescription/CollectionDescription.tsx
+++ b/resources/js/Components/Collections/CollectionDescription/CollectionDescription.tsx
@@ -43,7 +43,7 @@ export const CollectionDescription = ({
                     <LinkButton
                         data-testid="CollectionHeaderTop__about"
                         className={cn(
-                            "transition-default border-b border-dashed border-theme-secondary-900 hover:border-transparent hover:text-theme-hint-700",
+                            "transition-default border-b border-dashed border-theme-secondary-900 hover:border-transparent hover:text-theme-primary-700",
                             linkClassName,
                         )}
                         onClick={() => {
@@ -64,7 +64,7 @@ export const CollectionDescription = ({
                             data-testid="CollectionHeaderTop__description_modal"
                             className={cn(
                                 "text-theme-secondary-700 [&_div]:space-y-6",
-                                "[&_a]:text-theme-hint-600 hover:[&_a]:underline",
+                                "[&_a]:text-theme-primary-600 hover:[&_a]:underline",
                             )}
                         >
                             <Markdown
@@ -96,7 +96,7 @@ export const MarkdownImage = ({ alt, src }: { alt: string; src: string }): JSX.E
 const MarkdownLink = ({ href, children }: { href: string; children: ReactNode }): JSX.Element => (
     <span className="inline-flex flex-wrap">
         <Link
-            className="outline-offset-3 transition-default flex items-center space-x-2 whitespace-nowrap rounded-full text-theme-hint-600 underline decoration-transparent underline-offset-2 outline-none outline-3 hover:text-theme-hint-700 hover:decoration-theme-hint-700 focus-visible:outline-theme-hint-300"
+            className="outline-offset-3 transition-default flex items-center space-x-2 whitespace-nowrap rounded-full text-theme-primary-600 underline decoration-transparent underline-offset-2 outline-none outline-3 hover:text-theme-primary-700 hover:decoration-theme-primary-700 focus-visible:outline-theme-primary-300"
             href={href}
             external
             confirmBeforeProceeding

--- a/resources/js/Components/Collections/CollectionHeader/CollectionHeaderTop.tsx
+++ b/resources/js/Components/Collections/CollectionHeader/CollectionHeaderTop.tsx
@@ -107,7 +107,7 @@ export const CollectionHeaderTop = ({
                             <Link
                                 data-testid="CollectionHeaderTop__address"
                                 href={contractUrl}
-                                className="outline-offset-3 transition-default flex items-center space-x-2 whitespace-nowrap rounded-full text-theme-hint-600 underline decoration-transparent underline-offset-2 outline-none outline-3 hover:text-theme-hint-700 hover:decoration-theme-hint-700 focus-visible:outline-theme-hint-300"
+                                className="outline-offset-3 transition-default flex items-center space-x-2 whitespace-nowrap rounded-full text-theme-primary-600 underline decoration-transparent underline-offset-2 outline-none outline-3 hover:text-theme-primary-700 hover:decoration-theme-primary-700 focus-visible:outline-theme-primary-300"
                                 external
                             >
                                 <span>

--- a/resources/js/Components/Collections/CollectionName/CollectionName.tsx
+++ b/resources/js/Components/Collections/CollectionName/CollectionName.tsx
@@ -42,7 +42,7 @@ export const CollectionName = ({
                         <p
                             ref={collectionNameReference}
                             data-testid="CollectionName__name"
-                            className="group-hover md:leading-auto truncate text-sm font-medium leading-6 text-theme-secondary-900 group-hover:text-theme-hint-700 md:text-lg"
+                            className="group-hover md:leading-auto truncate text-sm font-medium leading-6 text-theme-secondary-900 group-hover:text-theme-primary-700 md:text-lg"
                         >
                             {collection.name}
                         </p>

--- a/resources/js/Components/Collections/Nfts/NftBackButton/NftBackButton.tsx
+++ b/resources/js/Components/Collections/Nfts/NftBackButton/NftBackButton.tsx
@@ -51,9 +51,9 @@ export const NftBackButton = ({ nft, url, className }: Properties): JSX.Element 
                 <Link
                     href={url}
                     className={cn(
-                        "transition-default text-theme-hint-600 underline decoration-transparent underline-offset-2 outline-none",
-                        "hover:text-theme-hint-700 hover:decoration-theme-hint-700",
-                        "focus-visible:decoration-theme-hint-700",
+                        "transition-default text-theme-primary-600 underline decoration-transparent underline-offset-2 outline-none",
+                        "hover:text-theme-primary-700 hover:decoration-theme-primary-700",
+                        "focus-visible:decoration-theme-primary-700",
                     )}
                 >
                     {nft.collection.name}

--- a/resources/js/Components/Collections/Nfts/NftHeader/NftBasicInfo.tsx
+++ b/resources/js/Components/Collections/Nfts/NftHeader/NftBasicInfo.tsx
@@ -29,7 +29,7 @@ export const NftBasicInfo = ({ nft }: Properties): JSX.Element => {
                 <LinkButton
                     data-testid="NftHeader__collectionName"
                     variant="link"
-                    textColor="text-theme-hint-600"
+                    textColor="text-theme-primary-600"
                     fontSize="text-sm"
                     onClick={() => {
                         router.visit(

--- a/resources/js/Components/Collections/Nfts/NftHeader/NftOwner.tsx
+++ b/resources/js/Components/Collections/Nfts/NftHeader/NftOwner.tsx
@@ -36,7 +36,7 @@ export const NftOwner = ({ nft }: Properties): JSX.Element => {
                     showExternalIcon={true}
                     className="ml-1 flex flex-row items-center"
                 >
-                    <span className="text-theme-hint-600">
+                    <span className="text-theme-primary-600">
                         <TruncateMiddle
                             length={8}
                             text={address}

--- a/resources/js/Components/Dialog.tsx
+++ b/resources/js/Components/Dialog.tsx
@@ -91,7 +91,7 @@ const Dialog = ({
                                     <div data-testid="Dialog__close">
                                         <button
                                             type="button"
-                                            className="transition-default flex h-8 w-8 items-center justify-center rounded-full text-theme-hint-900 hover:bg-theme-secondary-300"
+                                            className="transition-default flex h-8 w-8 items-center justify-center rounded-full text-theme-primary-900 hover:bg-theme-secondary-300"
                                             onClick={onClose}
                                         >
                                             <Icon

--- a/resources/js/Components/FeaturedCollectionsBanner/FeaturedCollectionsBanner.tsx
+++ b/resources/js/Components/FeaturedCollectionsBanner/FeaturedCollectionsBanner.tsx
@@ -21,7 +21,7 @@ export const FeaturedCollectionsBanner = ({
                     level={2}
                     className="whitespace-nowrap pt-0"
                 >
-                    <span className="text-theme-hint-600">{t("common.featured")}</span>
+                    <span className="text-theme-primary-600">{t("common.featured")}</span>
 
                     <span> {t("common.collections")}</span>
                 </Heading>

--- a/resources/js/Components/Form/Checkbox.tsx
+++ b/resources/js/Components/Form/Checkbox.tsx
@@ -9,13 +9,13 @@ export const Checkbox = ({ className, isInvalid = false, ...properties }: Proper
         data-testid="Checkbox"
         type="checkbox"
         className={cn(
-            "form-checkbox box-border h-5 w-5 rounded border-2 text-theme-hint-600 transition duration-100 ease-in",
+            "form-checkbox box-border h-5 w-5 rounded border-2 text-theme-primary-600 transition duration-100 ease-in",
             isInvalid
                 ? "border-theme-danger-400"
-                : "border-theme-secondary-300 enabled:hover:border-theme-hint-400 enabled:checked:hover:border-theme-hint-400",
+                : "border-theme-secondary-300 enabled:hover:border-theme-primary-400 enabled:checked:hover:border-theme-primary-400",
             "disabled:border-theme-secondary-200 disabled:bg-theme-secondary-100 disabled:checked:border-theme-secondary-100 disabled:hover:bg-theme-secondary-100",
             "focus:ring-0 focus:ring-transparent focus:ring-offset-0",
-            "focus-visible:ring-4 focus-visible:ring-theme-hint-300",
+            "focus-visible:ring-4 focus-visible:ring-theme-primary-300",
             className,
         )}
         {...properties}

--- a/resources/js/Components/Form/Listbox/Listbox.blocks.test.tsx
+++ b/resources/js/Components/Form/Listbox/Listbox.blocks.test.tsx
@@ -89,7 +89,7 @@ describe("Listbox", () => {
 
         await userEvent.click(screen.getByTestId("Listbox__trigger"));
 
-        expect(screen.getByTestId("ListboxOption")).toHaveClass("bg-theme-hint-100");
+        expect(screen.getByTestId("ListboxOption")).toHaveClass("bg-theme-primary-100");
     });
 });
 

--- a/resources/js/Components/Form/Listbox/Listbox.blocks.tsx
+++ b/resources/js/Components/Form/Listbox/Listbox.blocks.tsx
@@ -30,7 +30,7 @@ export const ListboxAvatar = ({
             className={cn(
                 "relative -top-px -mt-4 flex h-8 w-8 flex-shrink-0 flex-grow-0 items-center justify-center overflow-hidden rounded-full bg-theme-secondary-100 transition group-disabled:bg-theme-secondary-200",
                 {
-                    "group-enabled:bg-theme-hint-700 group-[:enabled:hover]:bg-theme-hint-800": variant === "primary",
+                    "group-enabled:bg-theme-primary-700 group-[:enabled:hover]:bg-theme-primary-800": variant === "primary",
                     "group-enabled:bg-theme-danger-600": variant === "danger",
                     "group-enabled:bg-theme-secondary-100": variant === undefined,
                 },
@@ -59,11 +59,11 @@ export const ListboxOption = ({
             cn(
                 "transition-default group relative flex h-11 cursor-default select-none items-center px-6 py-3",
                 {
-                    "cursor-pointer text-theme-secondary-700 hover:bg-theme-hint-50 hover:text-theme-secondary-900":
+                    "cursor-pointer text-theme-secondary-700 hover:bg-theme-primary-50 hover:text-theme-secondary-900":
                         !selected && isDisabled !== true,
-                    "bg-theme-hint-100 text-theme-secondary-900": (selected || isSelected) && !isTruthy(hasGradient),
-                    "bg-theme-hint-100 text-theme-hint-600": (selected || isSelected) && isTruthy(hasGradient),
-                    "bg-theme-hint-50 text-theme-secondary-900": active && !selected,
+                    "bg-theme-primary-100 text-theme-secondary-900": (selected || isSelected) && !isTruthy(hasGradient),
+                    "bg-theme-primary-100 text-theme-primary-600": (selected || isSelected) && isTruthy(hasGradient),
+                    "bg-theme-primary-50 text-theme-secondary-900": active && !selected,
                     "text-theme-secondary-500 hover:bg-transparent hover:text-theme-secondary-500":
                         isDisabled === true && !selected,
                 },
@@ -171,17 +171,17 @@ export const ListboxGradientButton = ({ children }: HTMLAttributes<HTMLDivElemen
     <HeadlessListbox.Button
         data-testid="ListboxGradientButton"
         className={cn(
-            "group relative block w-full rounded-xl border border-theme-secondary-400 px-5 py-2 text-left transition focus:outline-none enabled:focus:ring-2 enabled:focus:ring-theme-hint-300",
+            "group relative block w-full rounded-xl border border-theme-secondary-400 px-5 py-2 text-left transition focus:outline-none enabled:focus:ring-2 enabled:focus:ring-theme-primary-300",
             "disabled:bg-theme-secondary-50 disabled:text-theme-secondary-700",
         )}
     >
         {({ open }) => (
             <div className="flex items-center justify-between space-x-3">
-                <span className="flex-1 truncate text-xl font-bold leading-[1.875rem] text-theme-hint-600 md:text-2xl md:leading-8 lg:text-[2rem] lg:leading-[2.75rem]">
+                <span className="flex-1 truncate text-xl font-bold leading-[1.875rem] text-theme-primary-600 md:text-2xl md:leading-8 lg:text-[2rem] lg:leading-[2.75rem]">
                     {children}
                 </span>
 
-                <div className="pointer-events-none flex h-6 w-6 items-center justify-center rounded-full bg-theme-hint-600 text-white">
+                <div className="pointer-events-none flex h-6 w-6 items-center justify-center rounded-full bg-theme-primary-600 text-white">
                     <Icon
                         data-testid="ListboxButtonIcon"
                         name="ChevronDownSmall"

--- a/resources/js/Components/Form/Listbox/Listbox.blocks.tsx
+++ b/resources/js/Components/Form/Listbox/Listbox.blocks.tsx
@@ -30,7 +30,8 @@ export const ListboxAvatar = ({
             className={cn(
                 "relative -top-px -mt-4 flex h-8 w-8 flex-shrink-0 flex-grow-0 items-center justify-center overflow-hidden rounded-full bg-theme-secondary-100 transition group-disabled:bg-theme-secondary-200",
                 {
-                    "group-enabled:bg-theme-primary-700 group-[:enabled:hover]:bg-theme-primary-800": variant === "primary",
+                    "group-enabled:bg-theme-primary-700 group-[:enabled:hover]:bg-theme-primary-800":
+                        variant === "primary",
                     "group-enabled:bg-theme-danger-600": variant === "danger",
                     "group-enabled:bg-theme-secondary-100": variant === undefined,
                 },

--- a/resources/js/Components/Form/Listbox/Listbox.styles.ts
+++ b/resources/js/Components/Form/Listbox/Listbox.styles.ts
@@ -20,7 +20,7 @@ export const listboxButtonClassnames = ({
             "border-transparent font-medium": isNavigation,
         },
         {
-            "enabled:bg-theme-hint-600 enabled:text-white enabled:hover:bg-theme-hint-700": variant === "primary",
+            "enabled:bg-theme-primary-600 enabled:text-white enabled:hover:bg-theme-primary-700": variant === "primary",
             "enabled:bg-theme-danger-400 enabled:text-white enabled:hover:bg-theme-danger-500": variant === "danger",
             "enabled:bg-white enabled:text-theme-secondary-900": variant === undefined,
         },
@@ -40,13 +40,13 @@ export const listboxButtonClassnames = ({
                       "border-theme-secondary-400": !isTruthy(isNavigation),
                   },
                   {
-                      "enabled:border-theme-hint-600": variant === "primary",
+                      "enabled:border-theme-primary-600": variant === "primary",
                       "enabled:border-theme-danger-400": variant === "danger",
                   },
-                  "enabled:focus:ring-2 enabled:focus:ring-theme-hint-300",
+                  "enabled:focus:ring-2 enabled:focus:ring-theme-primary-300",
                   {
-                      "border-theme-hint-600 ring-1 ring-theme-hint-600": isOpen,
-                      "enabled:hover:ring-2 enabled:hover:ring-theme-hint-100": !isOpen,
+                      "border-theme-primary-600 ring-1 ring-theme-primary-600": isOpen,
+                      "enabled:hover:ring-2 enabled:hover:ring-theme-primary-100": !isOpen,
                   },
               ],
         "disabled:bg-theme-secondary-50 disabled:text-theme-secondary-700",

--- a/resources/js/Components/Form/Radio.tsx
+++ b/resources/js/Components/Form/Radio.tsx
@@ -12,13 +12,13 @@ export const Radio = forwardRef<HTMLInputElement, Properties>(
             type="radio"
             ref={reference}
             className={cn(
-                "form-radio box-border h-5 w-5 border-2 text-theme-hint-600 transition duration-100 ease-in",
+                "form-radio box-border h-5 w-5 border-2 text-theme-primary-600 transition duration-100 ease-in",
                 isInvalid
                     ? "border-theme-danger-400"
-                    : "border-theme-secondary-300 enabled:hover:border-theme-hint-400 enabled:checked:hover:border-theme-hint-400",
+                    : "border-theme-secondary-300 enabled:hover:border-theme-primary-400 enabled:checked:hover:border-theme-primary-400",
                 "disabled:border-theme-secondary-200 disabled:bg-theme-secondary-100 disabled:checked:border-theme-secondary-100 disabled:hover:bg-theme-secondary-100",
                 "focus:ring-0 focus:ring-transparent focus:ring-offset-0",
-                "focus-visible:ring-4 focus-visible:ring-theme-hint-300",
+                "focus-visible:ring-4 focus-visible:ring-theme-primary-300",
                 className,
             )}
             {...properties}

--- a/resources/js/Components/Form/SearchInput.tsx
+++ b/resources/js/Components/Form/SearchInput.tsx
@@ -45,7 +45,7 @@ export const SearchInput = ({
                 <Icon
                     name="X"
                     size="md"
-                    className="text-theme-hint-900"
+                    className="text-theme-primary-900"
                 />
             </button>
         )}
@@ -54,7 +54,7 @@ export const SearchInput = ({
             name="MagnifyingGlass"
             size="md"
             className={classNames("pointer-events-none absolute right-0 top-0 mr-4 mt-4", {
-                "text-theme-hint-900": !disabled,
+                "text-theme-primary-900": !disabled,
                 "text-theme-secondary-500": disabled,
             })}
         />

--- a/resources/js/Components/Form/TextInput/TextInput.styles.ts
+++ b/resources/js/Components/Form/TextInput/TextInput.styles.ts
@@ -15,12 +15,12 @@ export const textInputDynamicClassnames = ({
         classes.push("border-theme-danger-400 ring-1 ring-theme-danger-400");
     } else {
         if (isFocused) {
-            classes.push("border-theme-hint-600 ring-1 ring-theme-hint-600");
+            classes.push("border-theme-primary-600 ring-1 ring-theme-primary-600");
         } else {
             classes.push("border-theme-secondary-400");
 
             if (isMouseOver && !isDisabled) {
-                classes.push("ring-2 ring-theme-hint-100");
+                classes.push("ring-2 ring-theme-primary-100");
             }
         }
     }

--- a/resources/js/Components/Form/TextInput/TextInput.test.tsx
+++ b/resources/js/Components/Form/TextInput/TextInput.test.tsx
@@ -81,7 +81,7 @@ describe("TextInput", () => {
 
         await userEvent.hover(screen.getByTestId("TextInput"));
 
-        expect(screen.getByTestId("TextInput")).toHaveClass("ring-2 ring-theme-hint-100");
+        expect(screen.getByTestId("TextInput")).toHaveClass("ring-2 ring-theme-primary-100");
     });
 
     it("should render text input avatar", () => {
@@ -116,6 +116,6 @@ describe("TextInput", () => {
 
         await userEvent.hover(screen.getByTestId("TextInput__button"));
 
-        expect(screen.getByTestId("TextInput")).not.toHaveClass("ring-2 ring-theme-hint-100");
+        expect(screen.getByTestId("TextInput")).not.toHaveClass("ring-2 ring-theme-primary-100");
     });
 });

--- a/resources/js/Components/Form/Toggle.tsx
+++ b/resources/js/Components/Form/Toggle.tsx
@@ -32,12 +32,12 @@ export const Toggle = ({
             id={id}
             className={cn(
                 className,
-                "relative inline-flex h-6 w-11 items-center rounded-full transition duration-200 ease-in-out focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-theme-hint-300",
+                "relative inline-flex h-6 w-11 items-center rounded-full transition duration-200 ease-in-out focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-theme-primary-300",
                 disabled
                     ? "bg-theme-secondary-200"
                     : [
                           checked
-                              ? "bg-theme-hint-600 hover:bg-theme-hint-700 active:bg-theme-hint-800"
+                              ? "bg-theme-primary-600 hover:bg-theme-primary-700 active:bg-theme-primary-800"
                               : "bg-theme-secondary-200 hover:bg-theme-secondary-300 active:bg-theme-secondary-400",
                       ],
             )}

--- a/resources/js/Components/Form/__snapshots__/Toggle.test.tsx.snap
+++ b/resources/js/Components/Form/__snapshots__/Toggle.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`Toggle > should render as checked 1`] = `
 <DocumentFragment>
   <button
     aria-checked="true"
-    class="relative inline-flex h-6 w-11 items-center rounded-full transition duration-200 ease-in-out focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-theme-hint-300 bg-theme-hint-600 hover:bg-theme-hint-700 active:bg-theme-hint-800"
+    class="relative inline-flex h-6 w-11 items-center rounded-full transition duration-200 ease-in-out focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-theme-primary-300 bg-theme-primary-600 hover:bg-theme-primary-700 active:bg-theme-primary-800"
     data-headlessui-state="checked"
     data-testid="Toggle"
     id="headlessui-switch-:r0:"
@@ -28,7 +28,7 @@ exports[`Toggle > should render as disabled 1`] = `
 <DocumentFragment>
   <button
     aria-checked="true"
-    class="relative inline-flex h-6 w-11 items-center rounded-full transition duration-200 ease-in-out focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-theme-hint-300 bg-theme-secondary-200"
+    class="relative inline-flex h-6 w-11 items-center rounded-full transition duration-200 ease-in-out focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-theme-primary-300 bg-theme-secondary-200"
     data-headlessui-state="checked"
     data-testid="Toggle"
     disabled=""
@@ -53,7 +53,7 @@ exports[`Toggle > should render as unchecked 1`] = `
 <DocumentFragment>
   <button
     aria-checked="false"
-    class="relative inline-flex h-6 w-11 items-center rounded-full transition duration-200 ease-in-out focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-theme-hint-300 bg-theme-secondary-200 hover:bg-theme-secondary-300 active:bg-theme-secondary-400"
+    class="relative inline-flex h-6 w-11 items-center rounded-full transition duration-200 ease-in-out focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-theme-primary-300 bg-theme-secondary-200 hover:bg-theme-secondary-300 active:bg-theme-secondary-400"
     data-headlessui-state=""
     data-testid="Toggle"
     id="headlessui-switch-:r1:"

--- a/resources/js/Components/Galleries/GalleryPage/GalleryActionToolbar/GalleryActionToolbar.tsx
+++ b/resources/js/Components/Galleries/GalleryPage/GalleryActionToolbar/GalleryActionToolbar.tsx
@@ -68,7 +68,7 @@ export const GalleryActionToolbar = ({
                                         iconPosition="right"
                                         variant="secondary"
                                         type="button"
-                                        iconClass="text-theme-hint-900"
+                                        iconClass="text-theme-primary-900"
                                         className="hidden h-full rounded-none rounded-r-xl border-none bg-transparent px-5 font-normal lg:block"
                                         onClick={onTemplateClick}
                                         data-testid="GalleryActionToolbar__template-button"
@@ -116,7 +116,7 @@ export const GalleryActionToolbar = ({
                                             iconPosition="right"
                                             variant="secondary"
                                             type="button"
-                                            iconClass="text-theme-hint-900"
+                                            iconClass="text-theme-primary-900"
                                             className="hidden h-full rounded-none rounded-r-xl border-none bg-transparent px-5 font-normal lg:block"
                                             onClick={onTemplateClick}
                                             data-testid="GalleryActionToolbar__template-button"
@@ -136,7 +136,7 @@ export const GalleryActionToolbar = ({
                                             <IconButton
                                                 onClick={onCoverClick}
                                                 icon="RoundedSquareWithPencil"
-                                                className="h-full rounded-none rounded-r-xl border-none bg-transparent font-normal text-theme-hint-900"
+                                                className="h-full rounded-none rounded-r-xl border-none bg-transparent font-normal text-theme-primary-900"
                                             />
                                         )}
 
@@ -144,7 +144,7 @@ export const GalleryActionToolbar = ({
                                             <Button
                                                 onClick={onCoverClick}
                                                 variant="bordered"
-                                                className="flex h-full rounded-none rounded-r-xl border-none bg-transparent font-normal text-theme-hint-900"
+                                                className="flex h-full rounded-none rounded-r-xl border-none bg-transparent font-normal text-theme-primary-900"
                                                 icon="RoundedSquareWithPencil"
                                                 iconPosition="right"
                                             >

--- a/resources/js/Components/Galleries/GalleryPage/GalleryCard.test.tsx
+++ b/resources/js/Components/Galleries/GalleryPage/GalleryCard.test.tsx
@@ -30,7 +30,7 @@ describe("GalleryCard", () => {
             </GalleryCard>,
         );
 
-        expect(screen.getByTestId("GalleryCard")).toHaveClass("outline-theme-hint-300");
+        expect(screen.getByTestId("GalleryCard")).toHaveClass("outline-theme-primary-300");
     });
 
     it("should render fixedOnMobile class", () => {

--- a/resources/js/Components/Galleries/GalleryPage/GalleryCard.tsx
+++ b/resources/js/Components/Galleries/GalleryPage/GalleryCard.tsx
@@ -62,7 +62,7 @@ const GalleryCardRoot = ({
                 data-testid="GalleryCard"
                 className={cn(
                     "transition-default group relative aspect-square overflow-hidden rounded-xl bg-theme-secondary-100 outline-none outline-3 outline-offset-0",
-                    { "outline-theme-hint-300": isSelected },
+                    { "outline-theme-primary-300": isSelected },
                     fixedOnMobile
                         ? {
                               "lg:cursor-pointer": className === undefined || !className.includes("cursor-"),
@@ -87,7 +87,7 @@ const GalleryCardOverlay = ({ children }: { children: React.ReactNode }): JSX.El
         <div
             data-testid="GalleryCard__overlay"
             className={cn(
-                "transition-default absolute inset-0 z-10 flex flex-col items-center justify-center overflow-hidden rounded-xl bg-theme-hint-50/75 px-8 text-center ",
+                "transition-default absolute inset-0 z-10 flex flex-col items-center justify-center overflow-hidden rounded-xl bg-theme-primary-50/75 px-8 text-center ",
                 {
                     "group-hover:pointer-events-auto group-hover:opacity-100 group-hover:backdrop-blur-md":
                         !fixedOnMobile,

--- a/resources/js/Components/Galleries/GalleryPage/GalleryCurator.tsx
+++ b/resources/js/Components/Galleries/GalleryPage/GalleryCurator.tsx
@@ -55,7 +55,7 @@ export const GalleryCurator = ({
                     <span>{t("pages.galleries.curated_by")}</span>
 
                     <div className="flex items-center space-x-2">
-                        <span className="transition-default flex text-theme-hint-600 group-hover:text-theme-hint-700 group-hover:decoration-theme-hint-700">
+                        <span className="transition-default flex text-theme-primary-600 group-hover:text-theme-primary-700 group-hover:decoration-theme-primary-700">
                             {truncate !== false ? renderTruncatedAddress(truncate) : renderAddress()}
                         </span>
 

--- a/resources/js/Components/Galleries/GalleryPage/GalleryHeading.tsx
+++ b/resources/js/Components/Galleries/GalleryPage/GalleryHeading.tsx
@@ -67,7 +67,7 @@ export const GalleryHeading = ({
 
             <div className="mt-2 text-sm font-medium leading-6 text-theme-secondary-900 md:text-base md:leading-7 lg:text-xl lg:leading-[1.875rem]">
                 <span
-                    className="text-theme-hint-600"
+                    className="text-theme-primary-600"
                     data-testid="NftsCount"
                 >
                     {headerData.nftsCount}{" "}
@@ -77,7 +77,7 @@ export const GalleryHeading = ({
                 <span className="lowercase"> {t("pages.galleries.from")} </span>
 
                 <span
-                    className="text-theme-hint-600"
+                    className="text-theme-primary-600"
                     data-testid="CollectionsCount"
                 >
                     {headerData.collectionsCount}{" "}
@@ -89,7 +89,7 @@ export const GalleryHeading = ({
                         <span>, {t("pages.galleries.valued_at")}</span>
 
                         <span>
-                            <span className="text-theme-hint-600">
+                            <span className="text-theme-primary-600">
                                 &nbsp;
                                 <FormatFiat
                                     value={value.toString()}

--- a/resources/js/Components/Galleries/GalleryPage/GalleryNfts.test.tsx
+++ b/resources/js/Components/Galleries/GalleryPage/GalleryNfts.test.tsx
@@ -17,14 +17,14 @@ describe("GalleryNfts", () => {
 
         expect(screen.getByTestId("GalleryNfts")).toBeInTheDocument();
 
-        expect(screen.getAllByTestId("GalleryCard")[0]).not.toHaveClass("outline-theme-hint-300");
+        expect(screen.getAllByTestId("GalleryCard")[0]).not.toHaveClass("outline-theme-primary-300");
 
         await userEvent.click(screen.getAllByTestId("GalleryCard")[0]);
 
-        expect(screen.getAllByTestId("GalleryCard")[0]).toHaveClass("outline-theme-hint-300");
+        expect(screen.getAllByTestId("GalleryCard")[0]).toHaveClass("outline-theme-primary-300");
 
         await userEvent.click(screen.getAllByTestId("GalleryCard")[0]);
 
-        expect(screen.getAllByTestId("GalleryCard")[0]).not.toHaveClass("outline-theme-hint-300");
+        expect(screen.getAllByTestId("GalleryCard")[0]).not.toHaveClass("outline-theme-primary-300");
     });
 });

--- a/resources/js/Components/Galleries/GalleryPage/GalleryNftsNft.test.tsx
+++ b/resources/js/Components/Galleries/GalleryPage/GalleryNftsNft.test.tsx
@@ -45,7 +45,7 @@ describe("GalleryNftsNft", () => {
         expect(nft.name).toBeDefined();
         assert(nft.name);
 
-        expect(screen.getByTestId("GalleryCard")).not.toHaveClass("outline-theme-hint-300");
+        expect(screen.getByTestId("GalleryCard")).not.toHaveClass("outline-theme-primary-300");
         expect(screen.getByTestId("GalleryNftsNft__price")).toHaveTextContent("11 ETH");
         expect(screen.getByTestId("GalleryNftsNft__name")).toHaveTextContent(nft.name);
     });
@@ -73,7 +73,7 @@ describe("GalleryNftsNft", () => {
             );
         });
 
-        expect(screen.getByTestId("GalleryCard")).toHaveClass("outline-theme-hint-300");
+        expect(screen.getByTestId("GalleryCard")).toHaveClass("outline-theme-primary-300");
     });
 
     it("should render without image", async () => {
@@ -229,7 +229,7 @@ describe("GalleryNftsNft", () => {
         expect(nft.name).toBeDefined();
         assert(nft.name);
 
-        expect(screen.getByTestId("GalleryCard")).not.toHaveClass("lg:outline-theme-hint-300");
+        expect(screen.getByTestId("GalleryCard")).not.toHaveClass("lg:outline-theme-primary-300");
         expect(screen.getByTestId("GalleryNftsNft__price")).toHaveTextContent("11 ETH");
         expect(screen.getByTestId("GalleryNftsNft__name")).toHaveTextContent(nft.name);
     });

--- a/resources/js/Components/Galleries/GalleryPage/GalleryNftsNft.tsx
+++ b/resources/js/Components/Galleries/GalleryPage/GalleryNftsNft.tsx
@@ -84,7 +84,7 @@ export const GalleryNftsNft = ({ nft, isSelected, onClick }: Properties): JSX.El
                         href={route("collections.view", {
                             slug: nft.collectionSlug,
                         })}
-                        className="outline-offset-3 transition-default mx-auto flex max-w-full items-center overflow-hidden truncate rounded-full px-2 text-theme-hint-600 underline decoration-transparent underline-offset-2 outline-none outline-3 hover:text-theme-hint-700 hover:decoration-theme-hint-700 focus-visible:outline-theme-hint-300"
+                        className="outline-offset-3 transition-default mx-auto flex max-w-full items-center overflow-hidden truncate rounded-full px-2 text-theme-primary-600 underline decoration-transparent underline-offset-2 outline-none outline-3 hover:text-theme-primary-700 hover:decoration-theme-primary-700 focus-visible:outline-theme-primary-300"
                         data-testid="GalleryNftsNft__website"
                     >
                         <span className="truncate">{nft.collectionName}</span>

--- a/resources/js/Components/Galleries/GalleryPage/GallerySelectTemplate/GallerySelectTemplate.tsx
+++ b/resources/js/Components/Galleries/GalleryPage/GallerySelectTemplate/GallerySelectTemplate.tsx
@@ -17,21 +17,21 @@ export const GallerySelectTemplate = ({
             <div className={className}>
                 <button
                     type="button"
-                    className="w-full overflow-hidden rounded-xl text-left outline outline-1 outline-theme-hint-600"
+                    className="w-full overflow-hidden rounded-xl text-left outline outline-1 outline-theme-primary-600"
                 >
-                    <div className="flex items-center justify-between bg-theme-hint-100 p-4">
+                    <div className="flex items-center justify-between bg-theme-primary-100 p-4">
                         <p className="text-sm font-medium text-theme-secondary-700">
                             {t("pages.galleries.create.templates.basic")}
                         </p>
 
                         <div>
-                            <span className="flex rounded-full bg-theme-hint-200 px-2 py-0.5 text-xs font-medium text-theme-hint-500">
+                            <span className="flex rounded-full bg-theme-primary-200 px-2 py-0.5 text-xs font-medium text-theme-primary-500">
                                 {t("common.selected")}
                             </span>
                         </div>
                     </div>
 
-                    <div className="bg-theme-hint-50 p-4">
+                    <div className="bg-theme-primary-50 p-4">
                         <img
                             src={basic}
                             alt={t("common.preview")}

--- a/resources/js/Components/Galleries/GalleryPage/GalleryUploadCover/GalleryUploadCover.blocks.tsx
+++ b/resources/js/Components/Galleries/GalleryPage/GalleryUploadCover/GalleryUploadCover.blocks.tsx
@@ -22,7 +22,7 @@ export const ImageEditActions = ({ src, onRemove, onUpload }: ImageEditActionsPr
     >
         <div className="transition-default absolute inset-0 z-10 flex items-center justify-center rounded-xl opacity-100 group-hover:opacity-100 md:bg-white/30 md:opacity-0 md:backdrop-blur-md">
             <div className="flex h-full items-end justify-center pb-4 md:items-center md:pb-0">
-                <div className="flex items-center space-x-3 rounded-full bg-theme-hint-50/50 p-1 backdrop-blur-lg backdrop-filter md:bg-white/30">
+                <div className="flex items-center space-x-3 rounded-full bg-theme-primary-50/50 p-1 backdrop-blur-lg backdrop-filter md:bg-white/30">
                     <IconButton
                         data-testid="ImageEditActions__upload"
                         icon="Upload"

--- a/resources/js/Components/Galleries/NftGalleryCard.blocks.tsx
+++ b/resources/js/Components/Galleries/NftGalleryCard.blocks.tsx
@@ -63,8 +63,8 @@ const NftImage = ({
             <div
                 data-testid={`NftImageGrid__selected--${nft.tokenNumber}`}
                 className={cn("transition-default pointer-events-none absolute inset-0 rounded-xl", {
-                    "border-2 border-theme-hint-600": isSelected,
-                    "border-theme-hint-100 group-hover:border-3": !isSelected,
+                    "border-2 border-theme-primary-600": isSelected,
+                    "border-theme-primary-100 group-hover:border-3": !isSelected,
                 })}
             >
                 <div
@@ -75,7 +75,7 @@ const NftImage = ({
                         },
                     )}
                 >
-                    <div className="flex h-7 w-7 items-center justify-center rounded-full bg-theme-hint-600 text-white">
+                    <div className="flex h-7 w-7 items-center justify-center rounded-full bg-theme-primary-600 text-white">
                         <Icon name="CheckSmall" />
                     </div>
                 </div>
@@ -235,7 +235,7 @@ export const GalleryHeading = ({
                 delay={[500, 0]}
             >
                 <Heading
-                    className="transition-default truncate pt-0.5 group-hover:text-theme-hint-700"
+                    className="transition-default truncate pt-0.5 group-hover:text-theme-primary-700"
                     level={4}
                     ref={truncateReference}
                 >

--- a/resources/js/Components/Galleries/NftGalleryCard.tsx
+++ b/resources/js/Components/Galleries/NftGalleryCard.tsx
@@ -12,8 +12,8 @@ export const NftGalleryCard = ({ gallery }: { gallery: App.Data.Gallery.GalleryD
             className={cn(
                 "transition-default m-1 box-content flex flex-col rounded-xl border border-theme-secondary-300",
                 "outline outline-3 outline-transparent",
-                "group-hover:outline-theme-hint-100",
-                "group-focus-visible:outline-theme-hint-300",
+                "group-hover:outline-theme-primary-100",
+                "group-focus-visible:outline-theme-primary-300",
             )}
             data-testid="NftGalleryCard"
         >

--- a/resources/js/Components/Galleries/NftGalleryCardEditable.tsx
+++ b/resources/js/Components/Galleries/NftGalleryCardEditable.tsx
@@ -80,7 +80,7 @@ export const NftGalleryCardEditable = ({
                 className={classNames(
                     "group flex aspect-square cursor-pointer items-center justify-center rounded-xl border hover:outline hover:outline-3",
                     {
-                        "border-theme-secondary-300 hover:outline-theme-hint-100": !isTruthy(error),
+                        "border-theme-secondary-300 hover:outline-theme-primary-100": !isTruthy(error),
                         "border-2 border-theme-danger-400 hover:outline-theme-danger-100": isTruthy(error),
                     },
                 )}

--- a/resources/js/Components/Layout/AuthOverlay/AuthOverlay.blocks.tsx
+++ b/resources/js/Components/Layout/AuthOverlay/AuthOverlay.blocks.tsx
@@ -79,7 +79,7 @@ export const SwitchingNetwork = (): JSX.Element => {
             <Icon
                 name="Spinner"
                 size="lg"
-                className="animate-spin text-theme-hint-600"
+                className="animate-spin text-theme-primary-600"
             />
             <span className="font-medium text-theme-secondary-900">{t("auth.wallet.switching_wallet")}</span>
         </OverlayButtonsWrapper>
@@ -94,7 +94,7 @@ export const ConnectingWallet = (): JSX.Element => {
             <Icon
                 name="Spinner"
                 size="xl"
-                className="animate-spin text-theme-hint-600"
+                className="animate-spin text-theme-primary-600"
             />
             <span className="font-medium text-theme-secondary-900">{t("auth.wallet.connecting")}</span>
         </OverlayButtonsWrapper>

--- a/resources/js/Components/Layout/Footer.tsx
+++ b/resources/js/Components/Layout/Footer.tsx
@@ -34,7 +34,7 @@ export const Footer = ({ withActionToolbar = false }: FooterProperties): JSX.Ele
                     <Link
                         variant="link"
                         href={t("urls.landing")}
-                        textColor="text-theme-hint-600"
+                        textColor="text-theme-primary-600"
                     >
                         {appName()}
                     </Link>
@@ -83,7 +83,7 @@ export const Footer = ({ withActionToolbar = false }: FooterProperties): JSX.Ele
                         <div className="mt-2 flex space-x-4 xs:mt-0 md:space-x-0">
                             <a
                                 href={t("urls.twitter").toString()}
-                                className="transition-default text-theme-secondary-700 hover:text-theme-hint-700 md:hidden"
+                                className="transition-default text-theme-secondary-700 hover:text-theme-primary-700 md:hidden"
                                 target="_blank"
                                 rel="noopener nofollow noreferrer"
                             >
@@ -96,7 +96,7 @@ export const Footer = ({ withActionToolbar = false }: FooterProperties): JSX.Ele
 
                             <a
                                 href={t("urls.twitter").toString()}
-                                className="button-icon group hidden border-transparent bg-transparent text-theme-secondary-700 hover:text-theme-hint-900 md:flex"
+                                className="button-icon group hidden border-transparent bg-transparent text-theme-secondary-700 hover:text-theme-primary-900 md:flex"
                                 target="_blank"
                                 rel="noopener nofollow noreferrer"
                             >
@@ -109,7 +109,7 @@ export const Footer = ({ withActionToolbar = false }: FooterProperties): JSX.Ele
 
                             <a
                                 href={t("urls.github").toString()}
-                                className="transition-default text-theme-secondary-700 hover:text-theme-hint-700 md:hidden"
+                                className="transition-default text-theme-secondary-700 hover:text-theme-primary-700 md:hidden"
                                 target="_blank"
                                 rel="noopener nofollow noreferrer"
                             >
@@ -122,7 +122,7 @@ export const Footer = ({ withActionToolbar = false }: FooterProperties): JSX.Ele
 
                             <a
                                 href={t("urls.github").toString()}
-                                className="button-icon group !ml-0 hidden border-transparent bg-transparent text-theme-secondary-700 hover:text-theme-hint-900 md:flex"
+                                className="button-icon group !ml-0 hidden border-transparent bg-transparent text-theme-secondary-700 hover:text-theme-primary-900 md:flex"
                                 target="_blank"
                                 rel="noopener nofollow noreferrer"
                             >
@@ -135,7 +135,7 @@ export const Footer = ({ withActionToolbar = false }: FooterProperties): JSX.Ele
 
                             <a
                                 href={t("urls.discord").toString()}
-                                className="transition-default text-theme-secondary-700 hover:text-theme-hint-700 md:hidden"
+                                className="transition-default text-theme-secondary-700 hover:text-theme-primary-700 md:hidden"
                                 target="_blank"
                                 rel="noopener nofollow noreferrer"
                             >
@@ -148,7 +148,7 @@ export const Footer = ({ withActionToolbar = false }: FooterProperties): JSX.Ele
 
                             <a
                                 href={t("urls.discord").toString()}
-                                className="button-icon group !ml-0 hidden border-transparent bg-transparent text-theme-secondary-700 hover:text-theme-hint-900 md:flex"
+                                className="button-icon group !ml-0 hidden border-transparent bg-transparent text-theme-secondary-700 hover:text-theme-primary-900 md:flex"
                                 target="_blank"
                                 rel="noopener nofollow noreferrer"
                             >

--- a/resources/js/Components/Layout/Logo.tsx
+++ b/resources/js/Components/Layout/Logo.tsx
@@ -28,7 +28,7 @@ export const Logo = ({
             <Link
                 href={t("urls.landing")}
                 rel="noreferrer"
-                className="flex items-center rounded-full outline-none outline-3 outline-offset-4 focus-visible:outline-theme-hint-300"
+                className="flex items-center rounded-full outline-none outline-3 outline-offset-4 focus-visible:outline-theme-primary-300"
                 data-testid="Logo__link"
             >
                 <Icon

--- a/resources/js/Components/Layout/Navbar.tsx
+++ b/resources/js/Components/Layout/Navbar.tsx
@@ -96,7 +96,7 @@ const Logo = (): JSX.Element => (
             href={route("galleries")}
             target="_blank"
             rel="noreferrer"
-            className="flex items-center rounded-full outline-none outline-3 outline-offset-4 focus-visible:outline-theme-hint-300"
+            className="flex items-center rounded-full outline-none outline-3 outline-offset-4 focus-visible:outline-theme-primary-300"
         >
             <Icon
                 name="Logo"

--- a/resources/js/Components/Link.test.tsx
+++ b/resources/js/Components/Link.test.tsx
@@ -69,7 +69,7 @@ describe("Link", () => {
             <Link
                 href="/test-link"
                 external
-                textColor="text-theme-hint-600"
+                textColor="text-theme-primary-600"
                 variant="link"
             >
                 <span data-testid="test"></span>
@@ -77,7 +77,7 @@ describe("Link", () => {
         );
 
         expect(screen.getByTestId("Link__anchor")).toBeInTheDocument();
-        expect(screen.getByTestId("Link__anchor")).toHaveClass("text-theme-hint-600");
+        expect(screen.getByTestId("Link__anchor")).toHaveClass("text-theme-primary-600");
     });
 });
 

--- a/resources/js/Components/Link.tsx
+++ b/resources/js/Components/Link.tsx
@@ -42,7 +42,7 @@ const variantClassName = ({
                 "outline-none outline-3 outline-offset-4",
                 {
                     "cursor-not-allowed text-theme-secondary-500": disabled === true,
-                    "hover:text-theme-hint-700 hover:decoration-theme-hint-700 focus-visible:outline-theme-hint-300":
+                    "hover:text-theme-primary-700 hover:decoration-theme-primary-700 focus-visible:outline-theme-primary-300":
                         disabled !== true,
                 },
                 className,

--- a/resources/js/Components/LoadingBlock/LoadingBlock.tsx
+++ b/resources/js/Components/LoadingBlock/LoadingBlock.tsx
@@ -9,7 +9,7 @@ export const LoadingBlock = ({ text }: { text?: string }): JSX.Element => (
             <Icon
                 size="xl"
                 name="Spinner"
-                className="animate-spin text-theme-hint-600"
+                className="animate-spin text-theme-primary-600"
             />
             <div>{text}</div>
         </div>

--- a/resources/js/Components/Navbar/AppMenuItem.tsx
+++ b/resources/js/Components/Navbar/AppMenuItem.tsx
@@ -27,7 +27,7 @@ export const AppMenuItem = ({
     const { t } = useTranslation();
 
     const defaultItemStyles =
-        "transition-default group flex w-full py-3 border-b-3 pt-6 pb-5 outline-0 focus-visible:ring focus-visible:ring-theme-hint-300 focus-visible:z-10";
+        "transition-default group flex w-full py-3 border-b-3 pt-6 pb-5 outline-0 focus-visible:ring focus-visible:ring-theme-primary-300 focus-visible:z-10";
     const defaultTextContainerStyles = cn("flex px-[1.125rem] border-r group-last:border-r-0", {
         "border-theme-secondary-800": dark,
         "border-theme-secondary-300": !dark,
@@ -59,7 +59,7 @@ export const AppMenuItem = ({
             className={cn(
                 defaultItemStyles,
                 {
-                    "border-theme-hint-900 bg-theme-secondary-50 text-theme-secondary-900": isActive && !dark,
+                    "border-theme-primary-900 bg-theme-secondary-50 text-theme-secondary-900": isActive && !dark,
                     "border-transparent hover:border-theme-secondary-300": !isActive && !dark,
                     "border-transparent": dark,
                 },
@@ -74,7 +74,7 @@ export const AppMenuItem = ({
                 <span
                     data-testid="AppMenuItem__Title"
                     className={cn(defaultTextStyles, {
-                        "text-white group-hover:text-theme-hint-500": dark,
+                        "text-white group-hover:text-theme-primary-500": dark,
                         "group-hover:text-theme-secondary-900": !dark,
                         "text-theme-secondary-900": isActive && !dark,
                         "text-theme-secondary-700": !isActive && !dark,

--- a/resources/js/Components/Navbar/MobileMenu.tsx
+++ b/resources/js/Components/Navbar/MobileMenu.tsx
@@ -204,7 +204,7 @@ export const NavLink = ({
                 "text-theme-secondary-700": !active,
             })}
         >
-            <div className="rounded-full bg-theme-hint-50 p-2.5">
+            <div className="rounded-full bg-theme-primary-50 p-2.5">
                 <Icon
                     name={icon}
                     size="lg"
@@ -275,7 +275,7 @@ const PortfolioBreakdown = ({ wallet }: { wallet: App.Data.Wallet.WalletData }):
 
                     <Link
                         href={route("dashboard")}
-                        className="transition-default text-sm font-medium text-theme-hint-600 hover:text-theme-hint-700"
+                        className="transition-default text-sm font-medium text-theme-primary-600 hover:text-theme-primary-700"
                     >
                         {t("common.my_wallet")}
                     </Link>
@@ -310,7 +310,7 @@ const Footer = ({ address }: { address: string }): JSX.Element => {
             >
                 <Icon
                     name="DoorExit"
-                    className="h-5 w-5 text-theme-hint-600"
+                    className="h-5 w-5 text-theme-primary-600"
                 />
             </Link>
         </div>

--- a/resources/js/Components/Navbar/UserDetails.tsx
+++ b/resources/js/Components/Navbar/UserDetails.tsx
@@ -105,9 +105,9 @@ export const UserDetails = ({ wallet, collectionCount, galleriesCount, currency 
                                                 <Link
                                                     href={route("dashboard")}
                                                     className={cn(
-                                                        "transition-default rounded-sm border-b border-transparent text-sm font-medium leading-none text-theme-hint-600 outline-none ",
-                                                        "hover:text-theme-hint-700",
-                                                        "focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-theme-hint-300 focus-visible:ring-offset-2",
+                                                        "transition-default rounded-sm border-b border-transparent text-sm font-medium leading-none text-theme-primary-600 outline-none ",
+                                                        "hover:text-theme-primary-700",
+                                                        "focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-theme-primary-300 focus-visible:ring-offset-2",
                                                     )}
                                                 >
                                                     {t("common.my_wallet")}
@@ -241,7 +241,7 @@ const DropdownNavigationLink = ({
         as={as}
         className={cn(
             "transition-default flex w-full items-center px-5 py-2.5 font-medium text-theme-secondary-700 md-lg:px-6",
-            "outline-none outline-3 outline-offset-[-3px] hover:bg-theme-secondary-200 hover:text-theme-secondary-900 focus-visible:outline-theme-hint-300",
+            "outline-none outline-3 outline-offset-[-3px] hover:bg-theme-secondary-200 hover:text-theme-secondary-900 focus-visible:outline-theme-primary-300",
         )}
     >
         <div className="flex items-center space-x-3 rounded-full">

--- a/resources/js/Components/OnboardingPanel.tsx
+++ b/resources/js/Components/OnboardingPanel.tsx
@@ -18,7 +18,7 @@ export const OnboardingPanel = ({ className, heading, subheading, ...properties 
         <div className="relative">
             <Icon
                 name="SpinnerNarrow"
-                className="h-40 w-40 animate-spin text-theme-hint-600"
+                className="h-40 w-40 animate-spin text-theme-primary-600"
             />
 
             <span className="absolute left-8 top-8 flex items-center justify-center">

--- a/resources/js/Components/Pagination/MobileButton.tsx
+++ b/resources/js/Components/Pagination/MobileButton.tsx
@@ -32,7 +32,7 @@ export const MobileButton = ({ page, totalPages, ...properties }: MobileButtonPr
                 {t("common.of")} {formattedTotalPages}
             </span>
 
-            <span className="text-theme-hint-900">
+            <span className="text-theme-primary-900">
                 <Icon name="Ellipsis" />
             </span>
         </button>

--- a/resources/js/Components/Pagination/PageInput.tsx
+++ b/resources/js/Components/Pagination/PageInput.tsx
@@ -30,7 +30,7 @@ export const PageInput = ({
                     onChange={(event) => {
                         onChange(event.target.value);
                     }}
-                    className="transition-default hidden-arrows w-full appearance-none rounded-full border border-theme-secondary-300 py-2 pl-4 pr-10 outline-4 outline-offset-0 placeholder:text-theme-secondary-500 focus:border-theme-hint-600 focus:outline-offset-0 focus:outline-theme-hint-300 focus:ring-0"
+                    className="transition-default hidden-arrows w-full appearance-none rounded-full border border-theme-secondary-300 py-2 pl-4 pr-10 outline-4 outline-offset-0 placeholder:text-theme-secondary-500 focus:border-theme-primary-600 focus:outline-offset-0 focus:outline-theme-primary-300 focus:ring-0"
                     placeholder={t("common.pagination_input_placeholder")}
                     data-testid="Pagination__PageInput__input"
                 />

--- a/resources/js/Components/Pagination/PageLink.tsx
+++ b/resources/js/Components/Pagination/PageLink.tsx
@@ -11,10 +11,10 @@ export const PageLink = ({ href, page, isActive = false }: PageLinkProperties): 
         <Link
             href={href}
             className={cn(
-                "transition-default flex items-center justify-center rounded-full font-medium outline-none ring-[3px] ring-transparent focus-visible:ring-theme-hint-300",
+                "transition-default flex items-center justify-center rounded-full font-medium outline-none ring-[3px] ring-transparent focus-visible:ring-theme-primary-300",
                 isActive
-                    ? "pointer-events-none bg-theme-hint-100 text-theme-hint-700"
-                    : "text-theme-hint-900 hover:bg-theme-secondary-300",
+                    ? "pointer-events-none bg-theme-primary-100 text-theme-primary-700"
+                    : "text-theme-primary-900 hover:bg-theme-secondary-300",
                 page < 10 ? "h-10 w-10" : "px-4 py-2",
             )}
             data-testid="Pagination__PageLink__link"

--- a/resources/js/Components/Pagination/Pagination.tsx
+++ b/resources/js/Components/Pagination/Pagination.tsx
@@ -102,7 +102,7 @@ export const Pagination = <T,>({ data, ...properties }: PaginationProperties<T>)
                             {showBeforeEllipsis && (
                                 <button
                                     type="button"
-                                    className="transition-default flex h-10 w-10 items-center space-x-4 rounded-full text-theme-secondary-700 outline-none ring-[3px] ring-transparent hover:bg-theme-secondary-300 focus-visible:ring-theme-hint-300"
+                                    className="transition-default flex h-10 w-10 items-center space-x-4 rounded-full text-theme-secondary-700 outline-none ring-[3px] ring-transparent hover:bg-theme-secondary-300 focus-visible:ring-theme-primary-300"
                                     data-testid="Pagination__EllipsisButton"
                                     onClick={() => {
                                         setShowInput(true);
@@ -124,7 +124,7 @@ export const Pagination = <T,>({ data, ...properties }: PaginationProperties<T>)
                             {showAfterEllipsis && (
                                 <button
                                     type="button"
-                                    className="transition-default flex h-10 w-10 items-center space-x-4 rounded-full text-theme-secondary-700 outline-none ring-[3px] ring-transparent hover:bg-theme-secondary-300 focus-visible:ring-theme-hint-300"
+                                    className="transition-default flex h-10 w-10 items-center space-x-4 rounded-full text-theme-secondary-700 outline-none ring-[3px] ring-transparent hover:bg-theme-secondary-300 focus-visible:ring-theme-primary-300"
                                     data-testid="Pagination__EllipsisButton__after"
                                     onClick={() => {
                                         setShowInput(true);

--- a/resources/js/Components/PortfolioBreakdown/DonutChart.tsx
+++ b/resources/js/Components/PortfolioBreakdown/DonutChart.tsx
@@ -103,7 +103,7 @@ export const DonutChart = ({ assets, currency, size = 276 }: DonutChartPropertie
             >
                 <Icon
                     name="Wallet"
-                    className="bg-theme-hint-50 text-theme-hint-600"
+                    className="bg-theme-primary-50 text-theme-primary-600"
                     size="lg"
                 />
 

--- a/resources/js/Components/PortfolioBreakdown/PortfolioBreakdown.contracts.ts
+++ b/resources/js/Components/PortfolioBreakdown/PortfolioBreakdown.contracts.ts
@@ -4,8 +4,8 @@ export const GRAPH_STROKE_COLOR_EMPTY = "stroke-theme-secondary-300";
 export const GRAPH_STROKE_COLOR_OTHER = "stroke-theme-secondary-400";
 
 export const GRAPH_STROKE_COLORS = [
-    "stroke-theme-primary-600",
-    "stroke-theme-primary-400",
+    "stroke-theme-hint-600",
+    "stroke-theme-hint-400",
     "stroke-theme-warning-400",
     "stroke-theme-success-400",
     "stroke-theme-danger-400",
@@ -13,8 +13,8 @@ export const GRAPH_STROKE_COLORS = [
 ] as const;
 
 export const GRAPH_BACKGROUND_COLORS = [
-    "bg-theme-primary-600",
-    "bg-theme-primary-400",
+    "bg-theme-hint-600",
+    "bg-theme-hint-400",
     "bg-theme-warning-400",
     "bg-theme-success-400",
     "bg-theme-danger-400",

--- a/resources/js/Components/PortfolioBreakdown/PortfolioBreakdown.contracts.ts
+++ b/resources/js/Components/PortfolioBreakdown/PortfolioBreakdown.contracts.ts
@@ -4,8 +4,8 @@ export const GRAPH_STROKE_COLOR_EMPTY = "stroke-theme-secondary-300";
 export const GRAPH_STROKE_COLOR_OTHER = "stroke-theme-secondary-400";
 
 export const GRAPH_STROKE_COLORS = [
-    "stroke-theme-hint-600",
-    "stroke-theme-hint-400",
+    "stroke-theme-primary-600",
+    "stroke-theme-primary-400",
     "stroke-theme-warning-400",
     "stroke-theme-success-400",
     "stroke-theme-danger-400",
@@ -13,8 +13,8 @@ export const GRAPH_STROKE_COLORS = [
 ] as const;
 
 export const GRAPH_BACKGROUND_COLORS = [
-    "bg-theme-hint-600",
-    "bg-theme-hint-400",
+    "bg-theme-primary-600",
+    "bg-theme-primary-400",
     "bg-theme-warning-400",
     "bg-theme-success-400",
     "bg-theme-danger-400",

--- a/resources/js/Components/PoweredByIcons.tsx
+++ b/resources/js/Components/PoweredByIcons.tsx
@@ -4,7 +4,7 @@ import { Icon } from "@/Components/Icon";
 const PoweredByLink = ({ url, icon, title }: { url: string; icon: React.ReactNode; title: string }): JSX.Element => (
     <a
         href={url}
-        className="transition-default text-theme-secondary-700 hover:text-theme-hint-700"
+        className="transition-default text-theme-secondary-700 hover:text-theme-primary-700"
         target="_blank"
         rel="noopener nofollow noreferrer"
     >

--- a/resources/js/Components/Sidebar/SidebarItem.tsx
+++ b/resources/js/Components/Sidebar/SidebarItem.tsx
@@ -28,7 +28,7 @@ export const SidebarItem = ({
             {isTruthy(icon) && (
                 <Icon
                     className={cn("transition-default ml-0 mr-2", {
-                        "border-transparent text-theme-hint-600": isSelected,
+                        "border-transparent text-theme-primary-600": isSelected,
                     })}
                     name={icon}
                     size="lg"

--- a/resources/js/Components/Tabs.test.tsx
+++ b/resources/js/Components/Tabs.test.tsx
@@ -92,7 +92,7 @@ describe("Tabs", () => {
             </Tabs.Link>,
         );
 
-        expect(screen.getByTestId("test").parentElement?.className).toContain("bg-theme-hint-100");
+        expect(screen.getByTestId("test").parentElement?.className).toContain("bg-theme-primary-100");
     });
     it("marks link as disabled", () => {
         render(

--- a/resources/js/Components/Tabs.tsx
+++ b/resources/js/Components/Tabs.tsx
@@ -23,7 +23,7 @@ const getTabClasses = ({
     className?: string;
 }): string => {
     const baseClassName = cn(
-        "transition-default flex items-center font-medium whitespace-nowrap outline-none outline-3 focus-visible:outline-theme-hint-300",
+        "transition-default flex items-center font-medium whitespace-nowrap outline-none outline-3 focus-visible:outline-theme-primary-300",
         {
             "cursor-pointer": !disabled,
             "cursor-not-allowed text-theme-secondary-500": disabled,
@@ -60,7 +60,7 @@ const getTabClasses = ({
         baseClassName,
         "rounded-xl sm:py-2.5 sm:px-3 outline-offset-0",
         {
-            "bg-theme-hint-100": selected,
+            "bg-theme-primary-100": selected,
             "hover:bg-theme-secondary-100 hover:text-theme-secondary-900": !selected && !disabled,
         },
         className,

--- a/resources/js/Components/Toast/Toast.blocks.tsx
+++ b/resources/js/Components/Toast/Toast.blocks.tsx
@@ -24,7 +24,7 @@ export const ToastCloseButton = ({
                 "hover:bg-theme-success-200 hover:text-theme-success-800": type === "success",
                 "hover:bg-theme-warning-200 hover:text-theme-warning-900": type === "warning",
                 "hover:bg-theme-danger-200 hover:text-theme-danger-800": type === "error",
-                "hover:bg-theme-hint-200 hover:text-theme-hint-800": type === "info",
+                "hover:bg-theme-primary-200 hover:text-theme-primary-800": type === "info",
             })}
         >
             <span className="sr-only">{t("common.close_toast")}</span>

--- a/resources/js/Components/Toast/Toast.test.tsx
+++ b/resources/js/Components/Toast/Toast.test.tsx
@@ -12,14 +12,14 @@ describe("Toast", () => {
         );
 
         expect(screen.getByTestId("Toast")).toBeInTheDocument();
-        expect(screen.getByTestId("Toast__wrapper")).toHaveClass("bg-theme-hint-100 text-theme-hint-700");
+        expect(screen.getByTestId("Toast__wrapper")).toHaveClass("bg-theme-primary-100 text-theme-primary-700");
     });
 
     it("should render info by default", () => {
         render(<Toast message="test" />);
 
         expect(screen.getByTestId("Toast")).toBeInTheDocument();
-        expect(screen.getByTestId("Toast__wrapper")).toHaveClass("bg-theme-hint-100 text-theme-hint-700");
+        expect(screen.getByTestId("Toast__wrapper")).toHaveClass("bg-theme-primary-100 text-theme-primary-700");
     });
 
     it("should render pending", () => {
@@ -79,7 +79,7 @@ describe("Toast", () => {
         );
 
         expect(screen.getByTestId("Toast")).toBeInTheDocument();
-        expect(screen.getByTestId("Toast__wrapper")).toHaveClass("bg-theme-hint-100 text-theme-hint-700");
+        expect(screen.getByTestId("Toast__wrapper")).toHaveClass("bg-theme-primary-100 text-theme-primary-700");
         expect(screen.getByText("Information")).toBeInTheDocument();
     });
 
@@ -123,6 +123,6 @@ describe("ToastTemplate", () => {
             expect(screen.getByTestId("Toast")).toBeInTheDocument();
         });
 
-        expect(screen.getByTestId("Toast__wrapper")).toHaveClass("bg-theme-hint-100 text-theme-hint-700");
+        expect(screen.getByTestId("Toast__wrapper")).toHaveClass("bg-theme-primary-100 text-theme-primary-700");
     });
 });

--- a/resources/js/Components/Toast/Toast.test.tsx
+++ b/resources/js/Components/Toast/Toast.test.tsx
@@ -12,14 +12,14 @@ describe("Toast", () => {
         );
 
         expect(screen.getByTestId("Toast")).toBeInTheDocument();
-        expect(screen.getByTestId("Toast__wrapper")).toHaveClass("bg-theme-primary-100 text-theme-primary-700");
+        expect(screen.getByTestId("Toast__wrapper")).toHaveClass("bg-theme-hint-100 text-theme-hint-700");
     });
 
     it("should render info by default", () => {
         render(<Toast message="test" />);
 
         expect(screen.getByTestId("Toast")).toBeInTheDocument();
-        expect(screen.getByTestId("Toast__wrapper")).toHaveClass("bg-theme-primary-100 text-theme-primary-700");
+        expect(screen.getByTestId("Toast__wrapper")).toHaveClass("bg-theme-hint-100 text-theme-hint-700");
     });
 
     it("should render pending", () => {
@@ -79,7 +79,7 @@ describe("Toast", () => {
         );
 
         expect(screen.getByTestId("Toast")).toBeInTheDocument();
-        expect(screen.getByTestId("Toast__wrapper")).toHaveClass("bg-theme-primary-100 text-theme-primary-700");
+        expect(screen.getByTestId("Toast__wrapper")).toHaveClass("bg-theme-hint-100 text-theme-hint-700");
         expect(screen.getByText("Information")).toBeInTheDocument();
     });
 
@@ -123,6 +123,6 @@ describe("ToastTemplate", () => {
             expect(screen.getByTestId("Toast")).toBeInTheDocument();
         });
 
-        expect(screen.getByTestId("Toast__wrapper")).toHaveClass("bg-theme-primary-100 text-theme-primary-700");
+        expect(screen.getByTestId("Toast__wrapper")).toHaveClass("bg-theme-hint-100 text-theme-hint-700");
     });
 });

--- a/resources/js/Components/Toast/Toast.tsx
+++ b/resources/js/Components/Toast/Toast.tsx
@@ -39,7 +39,7 @@ export const Toast = forwardRef<HTMLDivElement, ToastProperties>(
                         "bg-theme-success-100 text-theme-success-700": type === "success",
                         "bg-theme-warning-100 text-theme-warning-800": type === "warning",
                         "bg-theme-danger-100 text-theme-danger-700": type === "error",
-                        "bg-theme-primary-100 text-theme-primary-700": type === "info",
+                        "bg-theme-hint-100 text-theme-hint-700": type === "info",
                     })}
                 >
                     <div className="flex items-center space-x-2 px-6 py-3">

--- a/resources/js/Components/Toast/Toast.tsx
+++ b/resources/js/Components/Toast/Toast.tsx
@@ -39,7 +39,7 @@ export const Toast = forwardRef<HTMLDivElement, ToastProperties>(
                         "bg-theme-success-100 text-theme-success-700": type === "success",
                         "bg-theme-warning-100 text-theme-warning-800": type === "warning",
                         "bg-theme-danger-100 text-theme-danger-700": type === "error",
-                        "bg-theme-hint-100 text-theme-hint-700": type === "info",
+                        "bg-theme-primary-100 text-theme-primary-700": type === "info",
                     })}
                 >
                     <div className="flex items-center space-x-2 px-6 py-3">
@@ -71,7 +71,7 @@ export const Toast = forwardRef<HTMLDivElement, ToastProperties>(
                             "bg-theme-success-50 text-theme-secondary-700": type === "success",
                             "bg-theme-warning-50 text-theme-secondary-700": type === "warning",
                             "bg-theme-danger-50 text-theme-secondary-700": type === "error",
-                            "bg-theme-hint-50 text-theme-secondary-700": type === "info",
+                            "bg-theme-primary-50 text-theme-secondary-700": type === "info",
                         })}
                     >
                         {message}

--- a/resources/js/Components/Tokens/TokenBalance.tsx
+++ b/resources/js/Components/Tokens/TokenBalance.tsx
@@ -95,9 +95,9 @@ export const TokenBalance = ({ asset, currency, onSend, onReceive }: Properties)
                     </Tooltip>
                 </div>
 
-                <div className="h-2 bg-theme-hint-200">
+                <div className="h-2 bg-theme-primary-200">
                     <div
-                        className="h-2 bg-theme-hint-600"
+                        className="h-2 bg-theme-primary-600"
                         style={{
                             width: `${Math.round((Number(asset.percentage) + Number.EPSILON) * 100)}%`,
                         }}

--- a/resources/js/Components/Tokens/TokenLinks.tsx
+++ b/resources/js/Components/Tokens/TokenLinks.tsx
@@ -70,7 +70,7 @@ const SocialMediaLink = ({
             <Icon
                 name={icon}
                 size="md"
-                className="text-theme-hint-900"
+                className="text-theme-primary-900"
             />
         </a>
     </Tooltip>

--- a/resources/js/Components/Tokens/TokenLogo.test.tsx
+++ b/resources/js/Components/Tokens/TokenLogo.test.tsx
@@ -82,7 +82,7 @@ describe("TokenLogo", () => {
             />,
         );
 
-        expect(screen.getByTestId("TokenLogo__chain")).toHaveClass("border-theme-hint-100");
+        expect(screen.getByTestId("TokenLogo__chain")).toHaveClass("border-theme-primary-100");
     });
 
     it("should have size md by default", () => {

--- a/resources/js/Components/Tokens/TokenLogo.tsx
+++ b/resources/js/Components/Tokens/TokenLogo.tsx
@@ -33,8 +33,8 @@ export const TokenLogo = ({
                         data-testid="TokenLogo__chain"
                         className={cn(
                             "absolute bottom-0 right-0 overflow-hidden rounded-full",
-                            { "border-theme-hint-100 group-hover:border-theme-hint-100": isSelected },
-                            { "border-white group-hover:border-theme-hint-50": !isSelected },
+                            { "border-theme-primary-100 group-hover:border-theme-primary-100": isSelected },
+                            { "border-white group-hover:border-theme-primary-50": !isSelected },
                             { "-m-1.5 border-3": networkIconSize === "sm" },
                             { "-m-3 border-4": networkIconSize === "md" },
                         )}

--- a/resources/js/Components/Tokens/TokenTransactions/TokenTransactionDetailsSlider.tsx
+++ b/resources/js/Components/Tokens/TokenTransactions/TokenTransactionDetailsSlider.tsx
@@ -148,7 +148,7 @@ export const TokenTransactionDetailsSlider = ({
                                     <span className="flex items-center whitespace-nowrap">
                                         <Link
                                             href={transactionHashUrl}
-                                            className="outline-offset-3 transition-default flex items-center space-x-2 whitespace-nowrap rounded-full text-theme-hint-600 underline decoration-transparent underline-offset-2 outline-none outline-3 hover:text-theme-hint-700 hover:decoration-theme-hint-700 focus-visible:outline-theme-hint-300"
+                                            className="outline-offset-3 transition-default flex items-center space-x-2 whitespace-nowrap rounded-full text-theme-primary-600 underline decoration-transparent underline-offset-2 outline-none outline-3 hover:text-theme-primary-700 hover:decoration-theme-primary-700 focus-visible:outline-theme-primary-300"
                                             external
                                         >
                                             <TruncateMiddle
@@ -164,7 +164,7 @@ export const TokenTransactionDetailsSlider = ({
                                         <Icon
                                             name="Copy"
                                             size="md"
-                                            className="cursor-pointer text-theme-hint-600"
+                                            className="cursor-pointer text-theme-primary-600"
                                         />
                                     </Clipboard>
                                 </div>

--- a/resources/js/Components/Tokens/__snapshots__/TokenBalance.test.tsx.snap
+++ b/resources/js/Components/Tokens/__snapshots__/TokenBalance.test.tsx.snap
@@ -118,10 +118,10 @@ exports[`TokenBalance > should render 0 if an undefined fiat balance is provided
         </span>
       </div>
       <div
-        class="h-2 bg-theme-hint-200"
+        class="h-2 bg-theme-primary-200"
       >
         <div
-          class="h-2 bg-theme-hint-600"
+          class="h-2 bg-theme-primary-600"
           style="width: 50%;"
         />
       </div>
@@ -248,10 +248,10 @@ exports[`TokenBalance > should render in lg screen 1`] = `
         </span>
       </div>
       <div
-        class="h-2 bg-theme-hint-200"
+        class="h-2 bg-theme-primary-200"
       >
         <div
-          class="h-2 bg-theme-hint-600"
+          class="h-2 bg-theme-primary-600"
           style="width: 50%;"
         />
       </div>
@@ -378,10 +378,10 @@ exports[`TokenBalance > should render in md screen 1`] = `
         </span>
       </div>
       <div
-        class="h-2 bg-theme-hint-200"
+        class="h-2 bg-theme-primary-200"
       >
         <div
-          class="h-2 bg-theme-hint-600"
+          class="h-2 bg-theme-primary-600"
           style="width: 50%;"
         />
       </div>
@@ -508,10 +508,10 @@ exports[`TokenBalance > should render in md-lg screen 1`] = `
         </span>
       </div>
       <div
-        class="h-2 bg-theme-hint-200"
+        class="h-2 bg-theme-primary-200"
       >
         <div
-          class="h-2 bg-theme-hint-600"
+          class="h-2 bg-theme-primary-600"
           style="width: 50%;"
         />
       </div>
@@ -638,10 +638,10 @@ exports[`TokenBalance > should render in sm screen 1`] = `
         </span>
       </div>
       <div
-        class="h-2 bg-theme-hint-200"
+        class="h-2 bg-theme-primary-200"
       >
         <div
-          class="h-2 bg-theme-hint-600"
+          class="h-2 bg-theme-primary-600"
           style="width: 50%;"
         />
       </div>
@@ -768,10 +768,10 @@ exports[`TokenBalance > should render in xl screen 1`] = `
         </span>
       </div>
       <div
-        class="h-2 bg-theme-hint-200"
+        class="h-2 bg-theme-primary-200"
       >
         <div
-          class="h-2 bg-theme-hint-600"
+          class="h-2 bg-theme-primary-600"
           style="width: 50%;"
         />
       </div>
@@ -898,10 +898,10 @@ exports[`TokenBalance > should render in xs screen 1`] = `
         </span>
       </div>
       <div
-        class="h-2 bg-theme-hint-200"
+        class="h-2 bg-theme-primary-200"
       >
         <div
-          class="h-2 bg-theme-hint-600"
+          class="h-2 bg-theme-primary-600"
           style="width: 50%;"
         />
       </div>

--- a/resources/js/Components/TransactionFormSlider/Components/SearchAssets/SearchAssets.tsx
+++ b/resources/js/Components/TransactionFormSlider/Components/SearchAssets/SearchAssets.tsx
@@ -99,7 +99,7 @@ export const SearchAssets = ({
                     <Icon
                         size="xl"
                         name="SpinnerNarrow"
-                        className="m-auto animate-spin text-theme-hint-600"
+                        className="m-auto animate-spin text-theme-primary-600"
                     />
                 </div>
             )}

--- a/resources/js/Components/TransactionFormSlider/Steps/ExecutionStep.blocks.tsx
+++ b/resources/js/Components/TransactionFormSlider/Steps/ExecutionStep.blocks.tsx
@@ -29,7 +29,7 @@ export const Wallet = ({ address }: { address: string }): JSX.Element => {
                 <Icon
                     name="Copy"
                     size="md"
-                    className="cursor-pointer text-theme-hint-600"
+                    className="cursor-pointer text-theme-primary-600"
                 />
             </Clipboard>
         </div>
@@ -53,7 +53,7 @@ export const WaitingMessage = (): JSX.Element => {
                 <Icon
                     name="Spinner"
                     size="xl"
-                    className="mr-3 animate-spin text-theme-hint-600"
+                    className="mr-3 animate-spin text-theme-primary-600"
                 />
                 <span className="font-medium text-theme-secondary-900">
                     {t("pages.send_receive_panel.send.waiting_spinner_text")}

--- a/resources/js/Components/TransactionFormSlider/Steps/ResultStep.tsx
+++ b/resources/js/Components/TransactionFormSlider/Steps/ResultStep.tsx
@@ -139,7 +139,7 @@ export const ResultStep = ({
                                         href={t(`urls.explorers.${explorerUrlsKey}.transactions`, {
                                             id: hash,
                                         })}
-                                        className="outline-offset-3 transition-default flex items-center space-x-2 whitespace-nowrap rounded-full text-theme-hint-600 underline decoration-transparent underline-offset-2 outline-none outline-3 hover:text-theme-hint-700 hover:decoration-theme-hint-700 focus-visible:outline-theme-hint-300"
+                                        className="outline-offset-3 transition-default flex items-center space-x-2 whitespace-nowrap rounded-full text-theme-primary-600 underline decoration-transparent underline-offset-2 outline-none outline-3 hover:text-theme-primary-700 hover:decoration-theme-primary-700 focus-visible:outline-theme-primary-300"
                                         external
                                     >
                                         <TruncateMiddle
@@ -156,7 +156,7 @@ export const ResultStep = ({
                                     <Icon
                                         name="Copy"
                                         size="md"
-                                        className="cursor-pointer text-theme-hint-600"
+                                        className="cursor-pointer text-theme-primary-600"
                                     />
                                 </Clipboard>
                             </div>

--- a/resources/js/Components/TransactionStatuses/TransactionStatusError.tsx
+++ b/resources/js/Components/TransactionStatuses/TransactionStatusError.tsx
@@ -22,7 +22,7 @@ export const TransactionStatusError = ({ chainId, hash }: { chainId: number; has
             <span>{t("common.transaction_error_description_first_part")}</span>
             <Link
                 href={transactionHashUrl}
-                className="outline-offset-3 transition-default inline-flex items-center space-x-2 whitespace-nowrap rounded-full text-theme-hint-600 underline decoration-transparent underline-offset-2 outline-none outline-3 hover:text-theme-hint-700 hover:decoration-theme-hint-700 focus-visible:outline-theme-hint-300"
+                className="outline-offset-3 transition-default inline-flex items-center space-x-2 whitespace-nowrap rounded-full text-theme-primary-600 underline decoration-transparent underline-offset-2 outline-none outline-3 hover:text-theme-primary-700 hover:decoration-theme-primary-700 focus-visible:outline-theme-primary-300"
                 external
             >
                 {transactionExplorer}

--- a/resources/js/Components/WalletTokens/WalletTokensTable.blocks.tsx
+++ b/resources/js/Components/WalletTokens/WalletTokensTable.blocks.tsx
@@ -69,7 +69,7 @@ export const Token = memo(
                 <button
                     data-testid="WalletTokensTable__token"
                     type="button"
-                    className="transition-default group/token flex items-center space-x-3 rounded-2xl outline-none outline-3 outline-offset-4 focus-visible:outline-theme-hint-300"
+                    className="transition-default group/token flex items-center space-x-3 rounded-2xl outline-none outline-3 outline-offset-4 focus-visible:outline-theme-primary-300"
                     onClick={() => {
                         onClick(asset);
                     }}
@@ -93,7 +93,7 @@ export const Token = memo(
                 <div className="flex flex-col items-start space-y-0.5 whitespace-nowrap font-medium">
                     <span
                         data-testid="WalletTokensTable__token_symbol"
-                        className="text-sm leading-5.5 text-theme-secondary-900 group-hover/token:text-theme-hint-700 sm:text-base sm:leading-6"
+                        className="text-sm leading-5.5 text-theme-secondary-900 group-hover/token:text-theme-primary-700 sm:text-base sm:leading-6"
                     >
                         {asset.symbol}
                     </span>

--- a/resources/js/Components/WalletTokens/WalletTokensTable.tsx
+++ b/resources/js/Components/WalletTokens/WalletTokensTable.tsx
@@ -118,7 +118,7 @@ const WalletTokensTableItem = ({
     return (
         <button
             type="button"
-            className="flex items-center justify-between rounded-xl border border-theme-secondary-300 px-4 py-5 outline-none outline-3 outline-offset-0 transition-all hover:outline-theme-hint-300 focus-visible:outline-theme-hint-300"
+            className="flex items-center justify-between rounded-xl border border-theme-secondary-300 px-4 py-5 outline-none outline-3 outline-offset-0 transition-all hover:outline-theme-primary-300 focus-visible:outline-theme-primary-300"
             onClick={() => {
                 onDetailsClick(asset);
             }}

--- a/resources/js/Components/__snapshots__/Link.test.tsx.snap
+++ b/resources/js/Components/__snapshots__/Link.test.tsx.snap
@@ -47,7 +47,7 @@ exports[`Link > should render as external 1`] = `
 exports[`Link > should render with link variant classname 1`] = `
 <DocumentFragment>
   <a
-    class="transition-default rounded-full font-medium leading-5.5 underline decoration-transparent underline-offset-2 outline-none outline-3 outline-offset-4 hover:text-theme-hint-700 hover:decoration-theme-hint-700 focus-visible:outline-theme-hint-300 text-sm text-theme-secondary-700"
+    class="transition-default rounded-full font-medium leading-5.5 underline decoration-transparent underline-offset-2 outline-none outline-3 outline-offset-4 hover:text-theme-primary-700 hover:decoration-theme-primary-700 focus-visible:outline-theme-primary-300 text-sm text-theme-secondary-700"
     data-testid="Link__anchor"
     href="/test-link"
     rel="noreferrer"
@@ -93,7 +93,7 @@ exports[`LinkButton > should render 1`] = `
 exports[`LinkButton > should render with link variant classname 1`] = `
 <DocumentFragment>
   <button
-    class="transition-default rounded-full font-medium leading-5.5 underline decoration-transparent underline-offset-2 outline-none outline-3 outline-offset-4 hover:text-theme-hint-700 hover:decoration-theme-hint-700 focus-visible:outline-theme-hint-300 text-sm text-theme-secondary-700"
+    class="transition-default rounded-full font-medium leading-5.5 underline decoration-transparent underline-offset-2 outline-none outline-3 outline-offset-4 hover:text-theme-primary-700 hover:decoration-theme-primary-700 focus-visible:outline-theme-primary-300 text-sm text-theme-secondary-700"
     data-testid="Link__button"
     type="button"
   >

--- a/resources/js/Pages/Collections/Components/CollectionNavigation/CollectionNavigation.tsx
+++ b/resources/js/Pages/Collections/Components/CollectionNavigation/CollectionNavigation.tsx
@@ -31,13 +31,13 @@ const CollectionNavigationTab = forwardRef<
                             icon={icon}
                             variant="primary"
                             iconClass={classNames("w-[18px] h-auto", {
-                                "text-theme-hint-600": !selected && !disabled,
+                                "text-theme-primary-600": !selected && !disabled,
                                 "text-theme-secondary-500": disabled,
                             })}
                             className={classNames(
                                 "w-full justify-center disabled:bg-transparent disabled:text-theme-secondary-500 sm:w-auto",
                                 {
-                                    "bg-transparent text-theme-hint-900": !selected,
+                                    "bg-transparent text-theme-primary-900": !selected,
                                     [hoverClass]: !selected && !disabled,
                                 },
                             )}

--- a/resources/js/Pages/Collections/Components/CollectionNft/CollectionNft.tsx
+++ b/resources/js/Pages/Collections/Components/CollectionNft/CollectionNft.tsx
@@ -28,7 +28,7 @@ export const CollectionNft = ({
                 collection: nft.collectionSlug,
                 nft: nft.tokenNumber,
             })}
-            className="transition-default cursor-pointer rounded-xl border border-theme-secondary-300 p-2 ring-theme-hint-100 hover:ring-2"
+            className="transition-default cursor-pointer rounded-xl border border-theme-secondary-300 p-2 ring-theme-primary-100 hover:ring-2"
         >
             <span className="relative block">
                 <Img
@@ -37,7 +37,7 @@ export const CollectionNft = ({
                 />
 
                 <span className="absolute inset-x-0 top-0 m-4 flex">
-                    <span className="block flex h-7.5 min-w-0 items-center rounded-3xl bg-theme-hint-50/50 p-1 backdrop-blur-lg backdrop-filter">
+                    <span className="block flex h-7.5 min-w-0 items-center rounded-3xl bg-theme-primary-50/50 p-1 backdrop-blur-lg backdrop-filter">
                         <Tooltip
                             content={<span>#&nbsp;{nft.tokenNumber}</span>}
                             disabled={!isTokenNumberTruncated}

--- a/resources/js/Pages/Collections/Components/CollectionNftsGrid/NftsSorting.tsx
+++ b/resources/js/Pages/Collections/Components/CollectionNftsGrid/NftsSorting.tsx
@@ -78,7 +78,7 @@ const DropdownButton = ({
         className={cn(
             "transition-default cursor-pointer whitespace-nowrap px-6 py-2.5 text-left text-base font-medium",
             isActive
-                ? "bg-theme-hint-100 text-theme-hint-600"
+                ? "bg-theme-primary-100 text-theme-primary-600"
                 : "text-theme-secondary-700 hover:bg-theme-secondary-100 hover:text-theme-secondary-900",
         )}
         onClick={onClick}

--- a/resources/js/Pages/Collections/Components/CollectionsFilter/CollectionsFilterPopover.tsx
+++ b/resources/js/Pages/Collections/Components/CollectionsFilter/CollectionsFilterPopover.tsx
@@ -94,7 +94,7 @@ export const CollectionsFilterPopover = ({
 
 const PulsatingDot = (): JSX.Element => (
     <>
-        <span className="absolute right-0 top-0 mr-1 mt-0.5 flex h-1.5 w-1.5 rounded-full bg-theme-hint-600 ring-4 ring-white" />
-        <span className="animate-ping-slow absolute right-0 top-0 mr-1 mt-0.5 flex h-1.5 w-1.5 rounded-full bg-theme-hint-600" />
+        <span className="absolute right-0 top-0 mr-1 mt-0.5 flex h-1.5 w-1.5 rounded-full bg-theme-primary-600 ring-4 ring-white" />
+        <span className="animate-ping-slow absolute right-0 top-0 mr-1 mt-0.5 flex h-1.5 w-1.5 rounded-full bg-theme-primary-600" />
     </>
 );

--- a/resources/js/Pages/Collections/Components/CollectionsFilter/CollectionsSorting.tsx
+++ b/resources/js/Pages/Collections/Components/CollectionsFilter/CollectionsSorting.tsx
@@ -78,7 +78,7 @@ const DropdownButton = ({
         className={cn(
             "transition-default cursor-pointer whitespace-nowrap px-6 py-2.5 text-left text-base font-medium",
             isActive
-                ? "bg-theme-hint-100 text-theme-hint-600"
+                ? "bg-theme-primary-100 text-theme-primary-600"
                 : "text-theme-secondary-700 hover:bg-theme-secondary-100 hover:text-theme-secondary-900",
         )}
         onClick={onClick}

--- a/resources/js/Pages/Collections/Components/CollectionsHeading/CollectionsHeading.tsx
+++ b/resources/js/Pages/Collections/Components/CollectionsHeading/CollectionsHeading.tsx
@@ -37,7 +37,7 @@ export const CollectionsHeading = ({
                 components={[
                     <span
                         key="0"
-                        className="text-theme-hint-600"
+                        className="text-theme-primary-600"
                     />,
                 ]}
             />

--- a/resources/js/Pages/Collections/Nfts/Components/NftHeading/NftHeading.tsx
+++ b/resources/js/Pages/Collections/Nfts/Components/NftHeading/NftHeading.tsx
@@ -115,7 +115,7 @@ export const NftHeading = ({
 
     return (
         <div className="mx-auto -mt-6 flex w-full max-w-content flex-1 flex-col sm:-mt-8 lg:-mt-0 lg:px-8 2xl:px-0">
-            <div className="flex min-w-0 items-start justify-center gap-6 border border-theme-secondary-300 bg-theme-hint-50 md:p-6 lg:mb-6 lg:rounded-xl">
+            <div className="flex min-w-0 items-start justify-center gap-6 border border-theme-secondary-300 bg-theme-primary-50 md:p-6 lg:mb-6 lg:rounded-xl">
                 <NftImage nft={nft} />
 
                 <div className="hidden min-w-0 flex-1 lg:block">

--- a/resources/js/Pages/Collections/Nfts/Components/TraitsCarousel/TraitsCarousel.tsx
+++ b/resources/js/Pages/Collections/Nfts/Components/TraitsCarousel/TraitsCarousel.tsx
@@ -165,9 +165,9 @@ export const TraitsCarousel = ({
                                     {t("pages.collections.rarity")}
                                 </span>
 
-                                <div className="relative h-2 w-25 bg-theme-hint-200 md:w-full">
+                                <div className="relative h-2 w-25 bg-theme-primary-200 md:w-full">
                                     <div
-                                        className="left-0 h-full bg-theme-hint-600 md:absolute"
+                                        className="left-0 h-full bg-theme-primary-600 md:absolute"
                                         style={{ width: `${trait.nftsPercentage}%` }}
                                     />
                                 </div>

--- a/resources/js/Pages/Galleries/Components/GalleriesHeading/GalleriesHeading.tsx
+++ b/resources/js/Pages/Galleries/Components/GalleriesHeading/GalleriesHeading.tsx
@@ -17,18 +17,18 @@ export const GalleriesHeading = ({
 
     return (
         <Heading level={1}>
-            <span className="text-theme-hint-600">{galleriesCount}</span>
+            <span className="text-theme-primary-600">{galleriesCount}</span>
             <span className="lowercase">
                 {" "}
                 {tp("pages.galleries.galleries_count_simple", galleriesCount)} {t("pages.galleries.from")}{" "}
             </span>
-            <span className="text-theme-hint-600">{collectionsCount}</span>
+            <span className="text-theme-primary-600">{collectionsCount}</span>
             <span> {tp("pages.galleries.collections_count_simple", collectionsCount)}, </span>
             <span className="lowercase">{t("pages.galleries.featuring")} </span>
-            <span className="text-theme-hint-600">{nftsCount}</span>
+            <span className="text-theme-primary-600">{nftsCount}</span>
             <span> {tp("pages.galleries.nfts_count_simple", nftsCount)}, </span>
             <span className="lowercase">{t("pages.galleries.curated_by")} </span>
-            <span className="text-theme-hint-600">{usersCount}</span>
+            <span className="text-theme-primary-600">{usersCount}</span>
             <span> {tp("pages.galleries.users_count_simple", usersCount)}</span>
         </Heading>
     );

--- a/resources/js/Pages/Galleries/Components/GalleryGuestBanner/index.tsx
+++ b/resources/js/Pages/Galleries/Components/GalleryGuestBanner/index.tsx
@@ -18,7 +18,7 @@ const GalleryGuestBanner = ({ initialized, connecting, onClick }: Properties): J
             <div className="flex w-full flex-col gap-0.5 md:h-14 md:w-fit md:justify-center">
                 <h3 className="text-center text-xl font-medium capitalize leading-7 text-theme-secondary-900 md:text-left md:text-2xl">
                     {t("pages.galleries.guest_banner.title")}{" "}
-                    <span className="block text-theme-hint-600 sm:inline-block">{t("common.nft_gallery")}</span>
+                    <span className="block text-theme-primary-600 sm:inline-block">{t("common.nft_gallery")}</span>
                 </h3>
                 <p className="text-center text-xs font-medium text-theme-secondary-700 md:text-left md:text-sm">
                     {t("pages.galleries.guest_banner.subtitle")}

--- a/resources/js/Pages/Galleries/Components/GalleryListbox/GalleryListbox.tsx
+++ b/resources/js/Pages/Galleries/Components/GalleryListbox/GalleryListbox.tsx
@@ -27,7 +27,7 @@ export const GalleryListbox = ({
                         <Listbox.GradientButton>{selectedOption.label}</Listbox.GradientButton>
                     ) : (
                         <Listbox.Button isNavigation>
-                            <span className="text-theme-hint-600">{selectedOption.label}</span>
+                            <span className="text-theme-primary-600">{selectedOption.label}</span>
                         </Listbox.Button>
                     )}
                 </>

--- a/resources/js/Pages/Galleries/Components/GalleryNameInput/GalleryNameInput.tsx
+++ b/resources/js/Pages/Galleries/Components/GalleryNameInput/GalleryNameInput.tsx
@@ -29,7 +29,7 @@ export const GalleryNameInput = ({
                     "transition-default relative flex items-center justify-center rounded-xl border px-4 py-3",
                     {
                         "border-theme-danger-400 ring-1 ring-theme-danger-400": hasError || hasLimitError,
-                        "border-theme-secondary-400 focus-within:border-theme-hint-600 focus-within:ring-1 focus-within:ring-theme-hint-600":
+                        "border-theme-secondary-400 focus-within:border-theme-primary-600 focus-within:ring-1 focus-within:ring-theme-primary-600":
                             !hasError && !hasLimitError,
                     },
                 )}

--- a/stories/Base/Navbar/AppMenuItem.stories.tsx
+++ b/stories/Base/Navbar/AppMenuItem.stories.tsx
@@ -11,7 +11,7 @@ export default {
             options: ["Wallet", "Communities", "Collections"],
             defaultValue: "Wallet",
             mapping: {
-                Wallet: "bg-theme-hint-50 text-theme-hint-600",
+                Wallet: "bg-theme-primary-50 text-theme-primary-600",
                 Communities: "bg-theme-success-50 text-theme-success-600",
                 Collections: "bg-theme-warning-50 text-theme-warning-600",
             },

--- a/stories/Documentation/Color.tsx
+++ b/stories/Documentation/Color.tsx
@@ -82,18 +82,6 @@ const colors = {
         "bg-theme-info-800",
         "bg-theme-info-900",
     ],
-    hint: [
-        "bg-theme-hint-50",
-        "bg-theme-hint-100",
-        "bg-theme-hint-200",
-        "bg-theme-hint-300",
-        "bg-theme-hint-400",
-        "bg-theme-hint-500",
-        "bg-theme-hint-600",
-        "bg-theme-hint-700",
-        "bg-theme-hint-800",
-        "bg-theme-hint-900",
-    ],
 };
 
 /**

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -190,17 +190,6 @@ module.exports = {
             "theme-info-700": "rgb(var(--theme-color-info-700) / <alpha-value>)",
             "theme-info-800": "rgb(var(--theme-color-info-800) / <alpha-value>)",
             "theme-info-900": "rgb(var(--theme-color-info-900) / <alpha-value>)",
-
-            "theme-hint-50": "rgb(var(--theme-color-hint-50) / <alpha-value>)",
-            "theme-hint-100": "rgb(var(--theme-color-hint-100) / <alpha-value>)",
-            "theme-hint-200": "rgb(var(--theme-color-hint-200) / <alpha-value>)",
-            "theme-hint-300": "rgb(var(--theme-color-hint-300) / <alpha-value>)",
-            "theme-hint-400": "rgb(var(--theme-color-hint-400) / <alpha-value>)",
-            "theme-hint-500": "rgb(var(--theme-color-hint-500) / <alpha-value>)",
-            "theme-hint-600": "rgb(var(--theme-color-hint-600) / <alpha-value>)",
-            "theme-hint-700": "rgb(var(--theme-color-hint-700) / <alpha-value>)",
-            "theme-hint-800": "rgb(var(--theme-color-hint-800) / <alpha-value>)",
-            "theme-hint-900": "rgb(var(--theme-color-hint-900) / <alpha-value>)",
         },
     },
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -190,6 +190,17 @@ module.exports = {
             "theme-info-700": "rgb(var(--theme-color-info-700) / <alpha-value>)",
             "theme-info-800": "rgb(var(--theme-color-info-800) / <alpha-value>)",
             "theme-info-900": "rgb(var(--theme-color-info-900) / <alpha-value>)",
+
+            "theme-hint-50": "rgb(var(--theme-color-hint-50) / <alpha-value>)",
+            "theme-hint-100": "rgb(var(--theme-color-hint-100) / <alpha-value>)",
+            "theme-hint-200": "rgb(var(--theme-color-hint-200) / <alpha-value>)",
+            "theme-hint-300": "rgb(var(--theme-color-hint-300) / <alpha-value>)",
+            "theme-hint-400": "rgb(var(--theme-color-hint-400) / <alpha-value>)",
+            "theme-hint-500": "rgb(var(--theme-color-hint-500) / <alpha-value>)",
+            "theme-hint-600": "rgb(var(--theme-color-hint-600) / <alpha-value>)",
+            "theme-hint-700": "rgb(var(--theme-color-hint-700) / <alpha-value>)",
+            "theme-hint-800": "rgb(var(--theme-color-hint-800) / <alpha-value>)",
+            "theme-hint-900": "rgb(var(--theme-color-hint-900) / <alpha-value>)",
         },
     },
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

We used `theme-hint` as the primary/brand color for everything. However, `theme-primary` is a random set of colors that don't seem to be used anywhere at all. Instead of having to type "theme-hint" all the time, I want to be able to type `text-theme-primary-600` and use our primary purple color.

I have now replaced all "theme-hint" with "theme-primary" so you can use our purple as primary colors. Just something that has been bothering me. Please discuss.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
