### PR TITLE
feat: sort collections by name in asc order by default

### DIFF
--- a/app/Http/Controllers/CollectionController.php
+++ b/app/Http/Controllers/CollectionController.php
@@ -67,7 +67,7 @@ class CollectionController extends Controller
         $cache = new UserCache($user);
 
         $sortBy = in_array($request->query('sort'), ['oldest', 'received', 'name', 'floor-price', 'value', 'chain']) ? $request->query('sort') : null;
-        $defaultSortDirection = $sortBy === null ? 'desc' : 'asc';
+        $defaultSortDirection = $sortBy === null ? 'asc' : 'desc';
 
         $sortDirection = in_array($request->query('direction'), ['asc', 'desc']) ? $request->query('direction') : $defaultSortDirection;
 
@@ -79,12 +79,12 @@ class CollectionController extends Controller
                 ->forCollectionData($user)
                 ->when($showHidden, fn ($q) => $q->whereIn('collections.id', $user->hiddenCollections->modelKeys()))
                 ->when(! $showHidden, fn ($q) => $q->whereNotIn('collections.id', $user->hiddenCollections->modelKeys()))
-                ->when($sortBy === 'name', fn ($q) => $q->orderBy('name', $sortDirection))
+                ->when($sortBy === 'name' || $sortBy === null, fn ($q) => $q->orderByName($sortDirection))
                 ->when($sortBy === 'floor-price', fn ($q) => $q->orderByFloorPrice($sortDirection, $user->currency()))
-                ->when($sortBy === 'value' || $sortBy === null, fn ($q) => $q->orderByValue($user->wallet, $sortDirection, $user->currency()))
+                ->when($sortBy === 'value', fn ($q) => $q->orderByValue($user->wallet, $sortDirection, $user->currency()))
                 ->when($sortBy === 'chain', fn ($q) => $q->orderByChainId($sortDirection))
                 ->when($sortBy === 'oldest', fn ($q) => $q->orderByMintDate('asc'))
-                ->when($sortBy === 'received', fn ($q) => $q->orderByReceivedDate($user->wallet, 'desc'))
+                ->when($sortBy === 'received', fn ($q) => $q->orderByReceivedDate($user->wallet, $sortDirection))
                 ->search($user, $searchQuery)
                 ->paginate(25);
 

--- a/app/Http/Controllers/CollectionController.php
+++ b/app/Http/Controllers/CollectionController.php
@@ -84,7 +84,7 @@ class CollectionController extends Controller
                 ->when($sortBy === 'value', fn ($q) => $q->orderByValue($user->wallet, $sortDirection, $user->currency()))
                 ->when($sortBy === 'chain', fn ($q) => $q->orderByChainId($sortDirection))
                 ->when($sortBy === 'oldest', fn ($q) => $q->orderByMintDate('asc'))
-                ->when($sortBy === 'received', fn ($q) => $q->orderByReceivedDate($user->wallet, $sortDirection))
+                ->when($sortBy === 'received', fn ($q) => $q->orderByReceivedDate($user->wallet, 'desc'))
                 ->search($user, $searchQuery)
                 ->paginate(25);
 

--- a/app/Models/Collection.php
+++ b/app/Models/Collection.php
@@ -219,6 +219,17 @@ class Collection extends Model
      * @param  'asc'|'desc'  $direction
      * @return Builder<self>
      */
+    public function scopeOrderByName(Builder $query, string $direction): Builder {
+        $nullsPosition = $direction === 'asc' ? 'NULLS FIRST' : 'NULLS LAST';
+
+        return $query->orderByRaw("lower(collections.name) {$direction} {$nullsPosition}");
+    }
+
+    /**
+     * @param  Builder<self>  $query
+     * @param  'asc'|'desc'  $direction
+     * @return Builder<self>
+     */
     public function scopeOrderByMintDate(Builder $query, string $direction): Builder
     {
         if ($direction === 'asc') {

--- a/app/Models/Collection.php
+++ b/app/Models/Collection.php
@@ -219,7 +219,8 @@ class Collection extends Model
      * @param  'asc'|'desc'  $direction
      * @return Builder<self>
      */
-    public function scopeOrderByName(Builder $query, string $direction): Builder {
+    public function scopeOrderByName(Builder $query, string $direction): Builder
+    {
         $nullsPosition = $direction === 'asc' ? 'NULLS FIRST' : 'NULLS LAST';
 
         return $query->orderByRaw("lower(collections.name) {$direction} {$nullsPosition}");

--- a/resources/js/Pages/Collections/Index.tsx
+++ b/resources/js/Pages/Collections/Index.tsx
@@ -95,7 +95,7 @@ const CollectionsIndex = ({
             view: displayType,
         });
     };
-
+    console.log(props);
     return (
         <DefaultLayout toastMessage={props.toast}>
             <Head title={title} />

--- a/resources/js/Pages/Collections/Index.tsx
+++ b/resources/js/Pages/Collections/Index.tsx
@@ -95,7 +95,7 @@ const CollectionsIndex = ({
             view: displayType,
         });
     };
-    console.log(props);
+
     return (
         <DefaultLayout toastMessage={props.toast}>
             <Head title={title} />

--- a/tests/App/Models/CollectionTest.php
+++ b/tests/App/Models/CollectionTest.php
@@ -749,6 +749,40 @@ it('can sort collections by nfts mint date', function () {
     ]);
 });
 
+it('can sort collections by name', function() {
+    $first = Collection::factory()->create([
+        'name' => ' '
+    ]);
+
+    $second = Collection::factory()->create([
+        'name' => 'A'
+    ]);
+
+    $third = Collection::factory()->create([
+        'name' => 'aB'
+    ]);
+
+    $fourth = Collection::factory()->create([
+        'name' => 'AZ'
+    ]);
+
+    $fitfh = Collection::factory()->create([
+        'name' => 'B'
+    ]);
+
+    $collections = Collection::orderByName('asc')->get();
+
+    expect($collections->modelKeys())->toBe([
+        $first->id, $second->id, $third->id, $fourth->id,   $fitfh->id,
+    ]);
+
+    $collections = Collection::orderByName('desc')->get();
+
+    expect($collections->modelKeys())->toBe([
+        $fitfh->id, $fourth->id, $third->id, $second->id, $first->id,
+    ]);
+});
+
 it('queries the collections for the collection data object', function () {
     $collection1 = Collection::factory()->create([
         'floor_price' => '123456789',

--- a/tests/App/Models/CollectionTest.php
+++ b/tests/App/Models/CollectionTest.php
@@ -749,25 +749,25 @@ it('can sort collections by nfts mint date', function () {
     ]);
 });
 
-it('can sort collections by name', function() {
+it('can sort collections by name', function () {
     $first = Collection::factory()->create([
-        'name' => ' '
+        'name' => ' ',
     ]);
 
     $second = Collection::factory()->create([
-        'name' => 'A'
+        'name' => 'A',
     ]);
 
     $third = Collection::factory()->create([
-        'name' => 'aB'
+        'name' => 'aB',
     ]);
 
     $fourth = Collection::factory()->create([
-        'name' => 'AZ'
+        'name' => 'AZ',
     ]);
 
     $fitfh = Collection::factory()->create([
-        'name' => 'B'
+        'name' => 'B',
     ]);
 
     $collections = Collection::orderByName('asc')->get();


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[collections] change sorting of Collections alphabetical by default](https://app.clickup.com/t/862kehzwv)

## Summary

<!-- What changes are being made? -->

- Collections are now sorted by name in `asc` order.
- New tests have been added for these changes.

<img width="1511" alt="image" src="https://github.com/ArdentHQ/dashbrd/assets/55117912/72c92d9e-e80f-4654-ac26-39985b706d1a">


## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
