### PR TITLE
refactor: soft delete gallery nfts

### DIFF
--- a/app/Http/Controllers/MyGalleryController.php
+++ b/app/Http/Controllers/MyGalleryController.php
@@ -109,7 +109,7 @@ class MyGalleryController extends Controller
     {
         $this->authorize('delete', $gallery);
 
-        $gallery->delete();
+        $gallery->forceDelete();
 
         return redirect()
             ->to(route('my-galleries'))

--- a/app/Models/Gallery.php
+++ b/app/Models/Gallery.php
@@ -73,7 +73,9 @@ class Gallery extends Model implements Viewable
      */
     public function nfts(): BelongsToMany
     {
-        return $this->belongsToMany(Nft::class, 'nft_gallery')->withPivot('order_index');
+        return $this->belongsToMany(Nft::class, 'nft_gallery')
+            ->whereNull('nft_gallery.deleted_at')
+            ->withPivot('order_index');
     }
 
     public function value(CurrencyCode $currency): ?float

--- a/app/Models/Gallery.php
+++ b/app/Models/Gallery.php
@@ -16,6 +16,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Notifications\Notification;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
@@ -28,7 +29,7 @@ use Spatie\Sluggable\SlugOptions;
  */
 class Gallery extends Model implements Viewable
 {
-    use BelongsToUser, CanBeLiked, HasFactory, HasSlug, InteractsWithViews, Reportable;
+    use BelongsToUser, CanBeLiked, HasFactory, HasSlug, InteractsWithViews, Reportable, SoftDeletes;
 
     /**
      * @var array<string>

--- a/database/migrations/2023_09_22_145935_update_prune_galleries_trigger.php
+++ b/database/migrations/2023_09_22_145935_update_prune_galleries_trigger.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        // This migration reads the same file as `2023_03_29_080204_create_prune_galleries_trigger.php`
+        // however the query on the file is an updated query which is going to
+        // drop the old trigger and replace it on production environments or in
+        // cases where the migration was already ran.
+        DB::unprepared(get_query('migrations.create_prune_galleries_trigger'));
+    }
+};

--- a/database/migrations/2023_10_02_220405_add_deleted_at_column_to_gallery_nfts.php
+++ b/database/migrations/2023_10_02_220405_add_deleted_at_column_to_gallery_nfts.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('nft_gallery', function (Blueprint $table) {
+            $table->softDeletes();
+        });
+    }
+};

--- a/database/migrations/2023_10_02_223941_add_deleted_at_to_galleries_table.php
+++ b/database/migrations/2023_10_02_223941_add_deleted_at_to_galleries_table.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('galleries', function (Blueprint $table) {
+            $table->softDeletes();
+        });
+    }
+};

--- a/database/migrations/2023_10_02_230839_create_recover_galleries_nfts_trigger.php
+++ b/database/migrations/2023_10_02_230839_create_recover_galleries_nfts_trigger.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        DB::unprepared(get_query('migrations.create_recover_galleries_nfts_trigger'));
+    }
+};

--- a/database/migrations/2023_10_02_230839_create_recover_galleries_trigger.php
+++ b/database/migrations/2023_10_02_230839_create_recover_galleries_trigger.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        DB::unprepared(get_query('migrations.create_recover_galleries_trigger'));
+    }
+};

--- a/queries/migrations.create_prune_galleries_trigger.sql
+++ b/queries/migrations.create_prune_galleries_trigger.sql
@@ -43,7 +43,6 @@ AND
         WHERE galleries.id = soft_deleted_nfts.gallery_id
     );
 
-
 -- Lastly, delete all empty galleries of old user
 DELETE FROM galleries
 WHERE

--- a/queries/migrations.create_prune_galleries_trigger.sql
+++ b/queries/migrations.create_prune_galleries_trigger.sql
@@ -11,17 +11,29 @@ SELECT g.user_id INTO _user_id FROM galleries g
                                         JOIN wallets w ON g.user_id = w.user_id AND w.id = OLD.wallet_id
     LIMIT 1;
 
--- Cleanup pivot table
-WITH removed_nfts AS (
+-- Mark all gallery nfts as soft deleted if no longer owned by any user
+WITH unassinged_nfts AS (
     SELECT gallery_id, nft_id FROM galleries
                                        JOIN nft_gallery ng on galleries.id = ng.gallery_id
-                                       JOIN nfts n on ng.nft_id = n.id AND (n.wallet_id IS NULL OR n.wallet_id != OLD.wallet_id OR n.deleted_at IS NOT NULL)
+                                       JOIN nfts n on ng.nft_id = n.id AND n.wallet_id IS NULL
     WHERE user_id = _user_id
 )
 UPDATE nft_gallery
     SET deleted_at = NOW()
-FROM removed_nfts rm
+FROM unassinged_nfts un
+WHERE nft_gallery.gallery_id = un.gallery_id AND nft_gallery.nft_id = un.nft_id;
+
+-- remove gallery nfts relationship if nft belongs to another user or is deleted
+WITH removed_nfts AS (
+    SELECT gallery_id, nft_id FROM galleries
+                                       JOIN nft_gallery ng on galleries.id = ng.gallery_id
+                                       JOIN nfts n on ng.nft_id = n.id AND (n.wallet_id != OLD.wallet_id OR n.deleted_at IS NOT NULL)
+    WHERE user_id = _user_id
+)
+DELETE FROM nft_gallery
+    USING removed_nfts rm
 WHERE nft_gallery.gallery_id = rm.gallery_id AND nft_gallery.nft_id = rm.nft_id;
+
 
 -- Mark all galleries with only soft deleted nfts as soft deleted
 WITH soft_deleted_nfts AS (

--- a/queries/migrations.create_prune_galleries_trigger.sql
+++ b/queries/migrations.create_prune_galleries_trigger.sql
@@ -4,7 +4,7 @@
 
 CREATE OR REPLACE FUNCTION prune_empty_galleries() RETURNS TRIGGER AS $_$
 DECLARE
-_user_id BIGINT;
+    _user_id BIGINT;
 BEGIN
     -- Fetch user id of old wallet
 SELECT g.user_id INTO _user_id FROM galleries g
@@ -33,6 +33,8 @@ WITH soft_deleted_nfts AS (
     SELECT gallery_id
     FROM nft_gallery
     WHERE deleted_at IS NOT NULL
+    AND nft_gallery.nft_id = NEW.id
+    AND NEW.wallet_id IS NULL
     GROUP BY gallery_id
     HAVING COUNT(*) = COUNT(deleted_at)
 )

--- a/queries/migrations.create_prune_galleries_trigger.sql
+++ b/queries/migrations.create_prune_galleries_trigger.sql
@@ -23,18 +23,6 @@ UPDATE nft_gallery
 FROM removed_nfts rm
 WHERE nft_gallery.gallery_id = rm.gallery_id AND nft_gallery.nft_id = rm.nft_id;
 
--- recover nfts that were soft deleted but are now owned by the wallet again
-WITH recovered_nfts AS (
-    SELECT gallery_id, nft_id FROM galleries
-    JOIN nft_gallery ng ON galleries.id = ng.gallery_id
-    JOIN nfts n ON ng.nft_id = n.id AND n.id = NEW.id AND n.wallet_id IS NOT NULL
-    WHERE user_id = _user_id
-)
-UPDATE nft_gallery
-    SET deleted_at = NULL
-FROM recovered_nfts rec
-WHERE nft_gallery.gallery_id = rec.gallery_id AND nft_gallery.nft_id = rec.nft_id;
-
 -- Mark all galleries with only soft deleted nfts as soft deleted
 WITH soft_deleted_nfts AS (
     SELECT gallery_id
@@ -54,6 +42,7 @@ AND
         FROM soft_deleted_nfts
         WHERE galleries.id = soft_deleted_nfts.gallery_id
     );
+
 
 -- Lastly, delete all empty galleries of old user
 DELETE FROM galleries

--- a/queries/migrations.create_prune_galleries_trigger.sql
+++ b/queries/migrations.create_prune_galleries_trigger.sql
@@ -12,16 +12,9 @@ SELECT g.user_id INTO _user_id FROM galleries g
     LIMIT 1;
 
 -- Mark all gallery nfts as soft deleted if no longer owned by any user
-WITH unassinged_nfts AS (
-    SELECT gallery_id, nft_id FROM galleries
-                                       JOIN nft_gallery ng on galleries.id = ng.gallery_id
-                                       JOIN nfts n on ng.nft_id = n.id AND n.wallet_id IS NULL
-    WHERE user_id = _user_id
-)
 UPDATE nft_gallery
-    SET deleted_at = NOW()
-FROM unassinged_nfts un
-WHERE nft_gallery.gallery_id = un.gallery_id AND nft_gallery.nft_id = un.nft_id;
+SET deleted_at = NOW()
+WHERE nft_gallery.nft_id = NEW.id AND NEW.wallet_id IS NULL;
 
 -- remove gallery nfts relationship if nft belongs to another user or is deleted
 WITH removed_nfts AS (
@@ -45,7 +38,7 @@ WITH soft_deleted_nfts AS (
 )
 
 UPDATE galleries
-SET deleted_at = NOW()
+    SET deleted_at = NOW()
 WHERE
     user_id = _user_id
 AND

--- a/queries/migrations.create_prune_galleries_trigger.sql
+++ b/queries/migrations.create_prune_galleries_trigger.sql
@@ -72,6 +72,7 @@ RETURN NEW;
 END;
 $_$ LANGUAGE plpgsql;
 
+DROP TRIGGER IF EXISTS prune_empty_galleries_on_nft_change on nfts;
 CREATE TRIGGER prune_empty_galleries_on_nft_change
     AFTER UPDATE ON nfts
     FOR EACH ROW WHEN ( (OLD.wallet_id IS NOT NULL AND NEW.wallet_id IS NULL) OR (OLD.wallet_id != NEW.wallet_id) OR (OLD.deleted_at IS NULL AND NEW.deleted_at IS NOT NULL))

--- a/queries/migrations.create_prune_galleries_trigger.sql
+++ b/queries/migrations.create_prune_galleries_trigger.sql
@@ -23,7 +23,19 @@ UPDATE nft_gallery
 FROM removed_nfts rm
 WHERE nft_gallery.gallery_id = rm.gallery_id AND nft_gallery.nft_id = rm.nft_id;
 
--- Mark all galleries with only soft deleted nfts as soft  deleted
+-- recover nfts that were soft deleted but are now owned by the wallet again
+WITH recovered_nfts AS (
+    SELECT gallery_id, nft_id FROM galleries
+    JOIN nft_gallery ng ON galleries.id = ng.gallery_id
+    JOIN nfts n ON ng.nft_id = n.id AND n.id = NEW.id AND n.wallet_id IS NOT NULL
+    WHERE user_id = _user_id
+)
+UPDATE nft_gallery
+    SET deleted_at = NULL
+FROM recovered_nfts rec
+WHERE nft_gallery.gallery_id = rec.gallery_id AND nft_gallery.nft_id = rec.nft_id;
+
+-- Mark all galleries with only soft deleted nfts as soft deleted
 WITH soft_deleted_nfts AS (
     SELECT gallery_id
     FROM nft_gallery

--- a/queries/migrations.create_recover_galleries_nfts_trigger.sql
+++ b/queries/migrations.create_recover_galleries_nfts_trigger.sql
@@ -3,16 +3,14 @@ RETURNS TRIGGER AS $$
 DECLARE
 _user_id BIGINT;
 BEGIN
-    -- Fetch user id of old wallet
-    SELECT g.user_id INTO _user_id FROM galleries g
-        JOIN wallets w ON g.user_id = w.user_id AND w.id = OLD.wallet_id
-    LIMIT 1;
-
+  
     WITH recovered_nfts AS (
         SELECT ng.gallery_id, ng.nft_id
         FROM nft_gallery ng
         JOIN nfts n ON ng.nft_id = n.id AND n.id = NEW.id AND n.wallet_id IS NOT NULL
         JOIN galleries g ON g.id = ng.gallery_id
+        JOIN wallets w ON g.user_id = w.user_id AND w.id = n.wallet_id
+        where ng.deleted_at IS NOT NULL 
     )
     UPDATE nft_gallery
         SET deleted_at = NULL

--- a/queries/migrations.create_recover_galleries_nfts_trigger.sql
+++ b/queries/migrations.create_recover_galleries_nfts_trigger.sql
@@ -1,0 +1,32 @@
+CREATE OR REPLACE FUNCTION recover_nft_gallery_relationship()
+RETURNS TRIGGER AS $$
+DECLARE
+_user_id BIGINT;
+BEGIN
+    -- Fetch user id of old wallet
+    SELECT g.user_id INTO _user_id FROM galleries g
+        JOIN wallets w ON g.user_id = w.user_id AND w.id = OLD.wallet_id
+    LIMIT 1;
+
+    WITH recovered_nfts AS (
+        SELECT ng.gallery_id, ng.nft_id
+        FROM nft_gallery ng
+        JOIN nfts n ON ng.nft_id = n.id AND n.id = NEW.id AND n.wallet_id IS NOT NULL
+        JOIN galleries g ON g.id = ng.gallery_id
+    )
+    UPDATE nft_gallery
+        SET deleted_at = NULL
+    FROM recovered_nfts rec
+    WHERE nft_gallery.gallery_id = rec.gallery_id AND nft_gallery.nft_id = rec.nft_id;
+    
+    -- Return NEW to proceed with the update
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Create the trigger to call recover_nft_gallery_relationship() after each update on nfts
+CREATE TRIGGER recover_nft_gallery_relationship_trigger
+AFTER UPDATE OF wallet_id ON nfts
+FOR EACH ROW
+WHEN (NEW.wallet_id IS NOT NULL AND (OLD.wallet_id IS NULL OR OLD.wallet_id != NEW.wallet_id))
+EXECUTE FUNCTION recover_nft_gallery_relationship();

--- a/queries/migrations.create_recover_galleries_trigger.sql
+++ b/queries/migrations.create_recover_galleries_trigger.sql
@@ -1,0 +1,26 @@
+CREATE OR REPLACE FUNCTION recover_gallery()
+RETURNS TRIGGER AS $$
+BEGIN
+    -- Check if the gallery associated with the updated NFT is soft-deleted
+    IF EXISTS (
+        SELECT 1
+        FROM galleries
+        WHERE galleries.id = NEW.gallery_id
+        AND galleries.deleted_at IS NOT NULL
+    ) THEN
+        -- If so, undelete the gallery
+        UPDATE galleries
+        SET deleted_at = NULL
+        WHERE id = NEW.gallery_id;
+    END IF;
+    -- Return NEW to proceed with the update
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Create the trigger to call recover_gallery() after each update on nft_gallery
+CREATE TRIGGER recover_gallery_trigger
+AFTER UPDATE ON nft_gallery
+FOR EACH ROW
+WHEN (NEW.deleted_at IS NULL AND OLD.deleted_at IS NOT NULL)
+EXECUTE FUNCTION recover_gallery();

--- a/tests/App/Jobs/FetchWalletNftsTest.php
+++ b/tests/App/Jobs/FetchWalletNftsTest.php
@@ -412,13 +412,13 @@ it('should delete gallery of previous owner if it becomes empty', function () {
     (new FetchWalletNfts($wallet2, $network))->handle();
 
     expect(Gallery::count())->toBe(1);
-    expect(Gallery::withTrashed()->count())->toBe(2);
+    expect(Gallery::withTrashed()->count())->toBe(1);
 
     expect($wallet1->nfts()->count())->toBe(2)
         ->and($wallet2->nfts()->count())->toBe(1)
         ->and(Gallery::where('name', 'BRDY')->first())->not()->toBeNull()
         ->and(Gallery::where('name', 'BRDY2')->first())->toBeNull()
-        ->and(Gallery::where('name', 'BRDY2')->withTrashed()->first())->not()->toBeNull();
+        ->and(Gallery::where('name', 'BRDY2')->withTrashed()->first())->toBeNull();
 
 });
 

--- a/tests/App/Jobs/FetchWalletNftsTest.php
+++ b/tests/App/Jobs/FetchWalletNftsTest.php
@@ -277,6 +277,8 @@ it('should recover a soft deleted gallery if a nft is added again', function () 
     $galleries[1]->nfts()->attach($nfts[2], ['order_index' => 0]);
 
     expect($wallet->nfts()->count())->toBe(3);
+    expect($galleries[0]->nfts()->count())->toBe(2);
+    expect($galleries[1]->nfts()->count())->toBe(1);
     expect(Gallery::count())->toBe(2);
 
     // Fetch, should soft delete the galleries and nfts
@@ -285,6 +287,8 @@ it('should recover a soft deleted gallery if a nft is added again', function () 
     (new FetchWalletNfts($wallet, $network))->handle();
 
     expect($wallet->nfts()->count())->toBe(0);
+    expect($galleries[0]->nfts()->count())->toBe(0);
+    expect($galleries[1]->nfts()->count())->toBe(0);
     expect(Gallery::count())->toBe(0);
 
     // Fetch again, should recover the galleries and nfts
@@ -292,7 +296,9 @@ it('should recover a soft deleted gallery if a nft is added again', function () 
     Cache::flush();
     (new FetchWalletNfts($wallet, $network))->handle();
 
-    expect($wallet->nfts()->count())->toBe(3);
+    expect($wallet->fresh()->nfts()->count())->toBe(3);
+    expect($galleries[0]->nfts()->count())->toBe(2);
+    expect($galleries[1]->nfts()->count())->toBe(1);
     expect(Gallery::count())->toBe(2);
 });
 

--- a/tests/App/Jobs/FetchWalletNftsTest.php
+++ b/tests/App/Jobs/FetchWalletNftsTest.php
@@ -157,7 +157,7 @@ it('should detach no longer owned nfts', function () {
     expect($wallet->nfts()->count())->toBe(2)->and(Nft::count())->toBe(3);
 });
 
-it('should soft delete gallery when all nfts have been removed', function () {
+it('should soft delete gallery when all nfts have been soft deleted', function () {
     Bus::fake();
 
     Alchemy::fake([
@@ -232,6 +232,66 @@ it('should soft delete gallery when all nfts have been removed', function () {
 
     // Still two in the database since both were soft deleted
     $this->assertDatabaseCount('galleries', 2);
+});
+
+it('should soft delete gallery when all nfts have been deleted', function () {
+    Bus::fake();
+
+    Alchemy::fake([
+        '*' => Http::sequence()
+            ->push(getTestNfts(3))
+            ->push(getTestNfts(3)),
+    ]);
+
+    $network = Network::polygon();
+    $wallet = Wallet::factory()->create();
+    $wallet2 = Wallet::factory()->create();
+
+    $this->assertDatabaseCount('collections', 0);
+    $this->assertDatabaseCount('nfts', 0);
+    $this->assertDatabaseCount('galleries', 0);
+
+    (new FetchWalletNfts($wallet, $network))->handle();
+
+    expect(Nft::count())->toBe(3);
+
+    $this->assertDatabaseCount('galleries', 0);
+
+    // Create 2 galleries with NFTs
+    $galleries = Gallery::factory()->createMany([
+        [
+            'user_id' => $wallet->user->id,
+            'name' => 'BRDY',
+            'cover_image' => 'BRDY',
+        ], [
+            'user_id' => $wallet->user->id,
+            'name' => 'BRDY2',
+            'cover_image' => 'BRDY2',
+        ],
+    ]);
+
+    $nfts = Nft::where('wallet_id', $wallet->id)->orderBy('collection_id')->orderBy('id')->get();
+
+    $galleries[0]->nfts()->attach($nfts[0], ['order_index' => 0]);
+    $galleries[0]->nfts()->attach($nfts[1], ['order_index' => 0]);
+    $galleries[1]->nfts()->attach($nfts[2], ['order_index' => 0]);
+
+    $this->assertDatabaseCount('nft_gallery', 3);
+    $this->assertDatabaseCount('galleries', 2);
+
+    // Fetch again, now the first gallery is deleted due to the NFTs being removed from the wallet
+    Carbon::setTestNow(now()->addSecond());
+
+    Cache::flush();
+
+    // assigning nfts to wallet 2
+    (new FetchWalletNfts($wallet2, $network))->handle();
+
+    // Nft gallery relationship and galleries should be completely deleted
+
+    $this->assertDatabaseCount('nft_gallery', 0);
+
+    $this->assertDatabaseCount('galleries', 0);
 });
 
 it('should recover a soft deleted gallery if a nft is added again', function () {

--- a/tests/App/Models/GalleryTest.php
+++ b/tests/App/Models/GalleryTest.php
@@ -9,6 +9,7 @@ use App\Models\Nft;
 use App\Models\Report;
 use App\Models\Token;
 use App\Models\User;
+use Carbon\Carbon;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Config;
 
@@ -27,6 +28,17 @@ it('can retrieve the nfts that belong to the gallery', function () {
     $gallery->nfts()->attach($nft->id, ['order_index' => 1]);
 
     expect($gallery->nfts()->count())->toBe(1);
+});
+
+it('doest not retrieve soft deleted nfts', function () {
+    $nft = Nft::factory()->create();
+    $gallery = Gallery::factory()->create();
+
+    expect($gallery->nfts()->count())->toBe(0);
+
+    $gallery->nfts()->attach($nft->id, ['order_index' => 1, 'deleted_at' => Carbon::now()]);
+
+    expect($gallery->nfts()->count())->toBe(0);
 });
 
 it('should add a like to a gallery', function () {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

There is not really easy to test so a careful analysis to the querys is goint to be necessary

Whats expected is the following:

1. When a gallery nft is unassigned from a wallet (no longer belong to wallet) is soft deleted from the gallery and should not appear in the gallery view page
2. if a nft is assigned again it appears in the gallery again
3. if all nfts from the gallery are unassigned the gallery is also soft delted
4. if the nft belongs to the gallery again the gallery is recovered with that nft
5. if the nft changes to another owner is completely removed from the gallery
6. if all nfts are completely removed from a gallery the gallery is also completely removed

https://app.clickup.com/t/8678u37n1

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
