### PR TITLE
refactor: use `EXISTS` instead of `JOIN` when checking for a collection's spam contract existence

### DIFF
--- a/app/Console/Commands/FetchCollectionBannerBatch.php
+++ b/app/Console/Commands/FetchCollectionBannerBatch.php
@@ -41,24 +41,24 @@ class FetchCollectionBannerBatch extends Command
 
         $networks->map(function ($network) {
             Collection::query()
-                    ->select('id', 'address')
-                    ->where('network_id', $network->id)
-                    ->withoutSpamContracts()
-                    ->when($this->option('missing-only'), function (Builder $query) {
-                        $query->whereNull('extra_attributes->banner');
-                    })
-                    ->chunkById(100, function (IlluminateCollection $collections) use ($network) {
-                        $collections = $collections->filter(fn ($collection) => ! $collection->isBlacklisted());
+                ->select('id', 'address')
+                ->where('network_id', $network->id)
+                ->withoutSpamContracts()
+                ->when($this->option('missing-only'), function (Builder $query) {
+                    $query->whereNull('extra_attributes->banner');
+                })
+                ->chunkById(100, function (IlluminateCollection $collections) use ($network) {
+                    $collections = $collections->filter(fn ($collection) => ! $collection->isBlacklisted());
 
-                        $addresses = $collections->pluck('address')->toArray();
+                    $addresses = $collections->pluck('address')->toArray();
 
-                        Log::info('Dispatching FetchCollectionBannerBatchJob', [
-                            'network_id' => $network->id,
-                            'collection_addresses' => $addresses,
-                        ]);
+                    Log::info('Dispatching FetchCollectionBannerBatchJob', [
+                        'network_id' => $network->id,
+                        'collection_addresses' => $addresses,
+                    ]);
 
-                        FetchCollectionBannerBatchJob::dispatch($addresses, $network);
-                    });
+                    FetchCollectionBannerBatchJob::dispatch($addresses, $network);
+                });
         });
 
         return Command::SUCCESS;

--- a/app/Models/Collection.php
+++ b/app/Models/Collection.php
@@ -320,15 +320,24 @@ class Collection extends Model
     }
 
     /**
+     * @return HasOne<SpamContract>
+     */
+    public function spamContract(): HasOne
+    {
+        return $this->hasOne(SpamContract::class, 'address', 'address')->when(
+            $this->network_id !== null, fn ($query) => $query->where('network_id', $this->network_id)
+        );
+    }
+
+    /**
      * @param  Builder<self>  $query
      * @return Builder<self>
      */
     public function scopeWithoutSpamContracts(Builder $query): Builder
     {
-        return $query->leftJoin('spam_contracts', function ($join) {
-            $join->on('collections.network_id', '=', 'spam_contracts.network_id')
-                ->on('collections.address', '=', 'spam_contracts.address');
-        })->whereNull('spam_contracts.address');
+        return $query->whereDoesntHave('spamContract', function ($query) {
+            $query->selectRaw(1)->whereColumn('collections.network_id', 'spam_contracts.network_id');
+        });
     }
 
     /**


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
