### PR TITLE
fix: back button behavior for settings page

### DIFF
--- a/resources/js/Components/Layout/AuthOverlay/AuthOverlay.blocks.tsx
+++ b/resources/js/Components/Layout/AuthOverlay/AuthOverlay.blocks.tsx
@@ -144,7 +144,7 @@ export const ConnectWallet = ({
                 <Button
                     variant="secondary"
                     onClick={handleBackClick}
-                    className="xs:px-8 w-full justify-center xs:w-fit"
+                    className="w-full justify-center xs:w-fit xs:px-8"
                     data-testid="AuthOverlay__back-button"
                 >
                     {t("common.back")}

--- a/resources/js/Components/Layout/AuthOverlay/AuthOverlay.blocks.tsx
+++ b/resources/js/Components/Layout/AuthOverlay/AuthOverlay.blocks.tsx
@@ -144,7 +144,7 @@ export const ConnectWallet = ({
                 <Button
                     variant="secondary"
                     onClick={handleBackClick}
-                    className="px-8"
+                    className="xs:px-8 w-full justify-center xs:w-fit"
                     data-testid="AuthOverlay__back-button"
                 >
                     {t("common.back")}

--- a/resources/js/Components/Layout/AuthOverlay/AuthOverlay.blocks.tsx
+++ b/resources/js/Components/Layout/AuthOverlay/AuthOverlay.blocks.tsx
@@ -140,7 +140,7 @@ export const ConnectWallet = ({
                 </Button>
             )}
 
-            {isTruthy(showBackButton) && (
+            {isTruthy(showBackButton) && !showCloseButton && (
                 <Button
                     variant="secondary"
                     onClick={handleBackClick}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[settings] add "back" button to auth page?](https://app.clickup.com/t/862ked79u)

## Summary

<!-- What changes are being made? -->

- `Back` button behavior has been fixed when trying to access `Settings` page.
- Width for the button in small mobile screens has been fixed, too.

## Steps to reproduce

1. Run the app in `local` mode.
2. Connect your wallet and make sure you haven't signed anything.
3. Try to perform an action that requires a signature (for example, report a gallery).
4. Once the signature modal appears, open the user dropdown.
5. Click in `Settings` and see the magic ✨ 


https://github.com/ArdentHQ/dashbrd/assets/55117912/b8d62029-cde9-426a-97b1-9a1d0d6fdfc1


## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
