### PR TITLE
fix: correct colors for create gallery button

### DIFF
--- a/resources/js/Pages/Galleries/Components/GalleryGuestBanner/index.tsx
+++ b/resources/js/Pages/Galleries/Components/GalleryGuestBanner/index.tsx
@@ -30,7 +30,7 @@ const GalleryGuestBanner = ({ initialized, connecting, onClick }: Properties): J
             <div className="flex h-fit justify-center">
                 <Button
                     icon="Plus"
-                    className="justify-center py-2 sm:w-fit sm:px-6 dark:button-secondary-light md:button-light"
+                    className="dark:button-secondary-light md:button-light justify-center py-2 sm:w-fit sm:px-6"
                     disabled={connecting || !initialized}
                     onClick={onClick}
                     variant={isMdAndAbove ? "secondary" : "primary"}

--- a/resources/js/Pages/Galleries/Components/GalleryGuestBanner/index.tsx
+++ b/resources/js/Pages/Galleries/Components/GalleryGuestBanner/index.tsx
@@ -30,7 +30,7 @@ const GalleryGuestBanner = ({ initialized, connecting, onClick }: Properties): J
             <div className="flex h-fit justify-center">
                 <Button
                     icon="Plus"
-                    className="justify-center·py-2·sm:w-fit·sm:px-6 dark:button-secondary-light md:button-light bg-theme-secondary-100"
+                    className="justify-center py-2 sm:w-fit sm:px-6 dark:button-secondary-light md:button-light"
                     disabled={connecting || !initialized}
                     onClick={onClick}
                     variant={isMdAndAbove ? "secondary" : "primary"}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[galleries] Create Gallery button colour incorrect](https://app.clickup.com/t/862kfpmht)

## Summary

- Class names for `Create gallery` button have been fixed for mobile views, both in light and dark mode.


https://github.com/ArdentHQ/dashbrd/assets/55117912/08622909-e330-43f0-9462-f9dbbdd111fe



## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
