### PR TITLE
fix: handle existing local user when seeding

### DIFF
--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -14,18 +14,22 @@ class UserSeeder extends Seeder
 {
     public function run(): void
     {
-        $user = User::withoutEvents(fn () => User::factory()->create([
-            'username' => 'john.doe',
-        ]));
+        $wallet = Wallet::where('address', env('LOCAL_TESTING_ADDRESS'))->first();
 
-        $wallet = Wallet::withoutEvents(fn () => Wallet::factory()->create([
-            'user_id' => $user->id,
-            'address' => env('LOCAL_TESTING_ADDRESS'),
-        ]));
+        if ($wallet === null) {
+            $user = User::withoutEvents(fn () => User::factory()->create([
+                'username' => 'john.doe',
+            ]));
 
-        $user->update([
-            'wallet_id' => $wallet->id,
-        ]);
+            $wallet = Wallet::withoutEvents(fn () => Wallet::factory()->create([
+                'user_id' => $user->id,
+                'address' => env('LOCAL_TESTING_ADDRESS'),
+            ]));
+
+            $user->update([
+                'wallet_id' => $wallet->id,
+            ]);
+        }
     }
 
     /**


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

handles the scenario where you have the local user open in a tab while seeding the database

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
