### PR TITLE
fix: reset activity state if collection is invalid

### DIFF
--- a/app/Console/Commands/FetchCollectionActivity.php
+++ b/app/Console/Commands/FetchCollectionActivity.php
@@ -45,7 +45,7 @@ class FetchCollectionActivity extends Command
         };
 
         $this->forEachCollection(function ($collection) {
-            Job::dispatch($collection);
+            Job::dispatch($collection, forced: true);
         }, $queryCallback);
 
         return Command::SUCCESS;

--- a/app/Jobs/FetchCollectionActivity.php
+++ b/app/Jobs/FetchCollectionActivity.php
@@ -43,10 +43,20 @@ class FetchCollectionActivity implements ShouldQueue
     public function handle(MnemonicWeb3DataProvider $provider): void
     {
         if (! config('dashbrd.features.activities') || $this->shouldIgnoreCollection()) {
+            $this->collection->update([
+                'is_fetching_activity' => false,
+                'activity_updated_at' => now(),
+            ]);
+
             return;
         }
 
         if ($this->collection->isInvalid()) {
+            $this->collection->update([
+                'is_fetching_activity' => false,
+                'activity_updated_at' => now(),
+            ]);
+
             return;
         }
 
@@ -147,6 +157,6 @@ class FetchCollectionActivity implements ShouldQueue
 
     public function retryUntil(): DateTime
     {
-        return now()->addMinutes(10); // This is retry PER JOB (i.e. per request)...
+        return now()->addHours(2); // This is retry PER JOB (i.e. per request)...
     }
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

It could happen that if activity is "invalid" (spam or something) it will get stuck in this `is_fetching_activity=true` state. Also I increased job duration to accommodate higher number of collections.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
