### PR TITLE
refactor: sort by recently received by default

### DIFF
--- a/app/Http/Controllers/CollectionController.php
+++ b/app/Http/Controllers/CollectionController.php
@@ -89,10 +89,10 @@ class CollectionController extends Controller
                 ->when(count($selectedChainIds) > 0, fn ($q) => $q->whereIn('collections.network_id', Network::whereIn('chain_id', $selectedChainIds)->pluck('id')))
                 ->when($sortBy === 'name', fn ($q) => $q->orderByName($sortDirection))
                 ->when($sortBy === 'floor-price', fn ($q) => $q->orderByFloorPrice($sortDirection, $user->currency()))
-                ->when($sortBy === 'value' || $sortBy === null, fn ($q) => $q->orderByValue($user->wallet, $sortDirection, $user->currency()))
+                ->when($sortBy === 'value', fn ($q) => $q->orderByValue($user->wallet, $sortDirection, $user->currency()))
                 ->when($sortBy === 'chain', fn ($q) => $q->orderByChainId($sortDirection))
                 ->when($sortBy === 'oldest', fn ($q) => $q->orderByMintDate('asc'))
-                ->when($sortBy === 'received', fn ($q) => $q->orderByReceivedDate($user->wallet, 'desc'))
+                ->when($sortBy === 'received' || $sortBy === null, fn ($q) => $q->orderByReceivedDate($user->wallet, 'desc'))
                 ->search($user, $searchQuery)
                 ->with('reports')
                 ->paginate(25);

--- a/resources/js/Pages/Collections/Index.tsx
+++ b/resources/js/Pages/Collections/Index.tsx
@@ -31,7 +31,7 @@ const CollectionsIndex = ({
     auth,
     initialStats,
     title,
-    sortBy,
+    sortBy = "received",
     sortDirection,
 }: {
     title: string;
@@ -130,7 +130,7 @@ const CollectionsIndex = ({
                         hiddenCount={hiddenCollectionAddresses.length}
                         searchQuery={query}
                         setSearchQuery={search}
-                        activeSort={sortBy}
+                        activeSort={sortBy ?? "received"}
                         onSort={sort}
                         onChangeVisibilityStatus={(isHidden) => {
                             reload({ showHidden: isHidden, selectedChainIds, page: 1 });


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[collections] change default sorting to Recently Received](https://app.clickup.com/t/862kg3dxw)

## Summary

- Collections are now sorted by `Recently Received` by default.
- The filter is also enabled by default in the UI.

## Steps to reproduce

1. Run the app in `local` or `testing_e2e` by default.
2. Go to `/collections` page and see the magic ✨ 


https://github.com/ArdentHQ/dashbrd/assets/55117912/c67c0d47-b0ef-45dc-aab4-8e9583e2465c



## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
