### PR TITLE
fix: do not index activity for prior indexed collections when running FetchWalletNfts

### DIFF
--- a/app/Support/Web3NftHandler.php
+++ b/app/Support/Web3NftHandler.php
@@ -168,9 +168,14 @@ class Web3NftHandler
         });
 
         if (Feature::active(Features::Collections->value)) {
-            CollectionModel::where('is_fetching_activity', false)->whereIn('id', $ids)->chunkById(100, function ($collections) {
-                $collections->each(fn ($collection) => FetchCollectionActivity::dispatch($collection)->onQueue(Queues::NFTS));
-            });
+            // Index activity only for newly created collections...
+            CollectionModel::query()
+                        ->where('is_fetching_activity', false)
+                        ->whereNull('activity_updated_at')
+                        ->whereIn('id', $ids)
+                        ->chunkById(100, function ($collections) {
+                            $collections->each(fn ($collection) => FetchCollectionActivity::dispatch($collection)->onQueue(Queues::NFTS));
+                        });
 
             $nftsGroupedByCollectionAddress->filter(fn (Web3NftData $nft) => $nft->mintedAt === null)->each(function (Web3NftData $nft) {
                 DetermineCollectionMintingDate::dispatch($nft)->onQueue(Queues::NFTS);


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/862kg5zc0

Basically added a check to do not run if `activity_updated_at` is not `null`.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
