### PR TITLE
perf: improve collections sorting query

### DIFF
--- a/app/Models/Collection.php
+++ b/app/Models/Collection.php
@@ -248,6 +248,8 @@ class Collection extends Model
     }
 
     /**
+     * Caller of this method should ensure that rows are grouped by `collections.id`
+     *
      * @param  Builder<self>  $query
      * @param  'asc'|'desc'  $direction
      * @return Builder<self>

--- a/app/Models/Collection.php
+++ b/app/Models/Collection.php
@@ -248,19 +248,23 @@ class Collection extends Model
     }
 
     /**
-     * Caller of this method should ensure that rows are grouped by `collections.id`
-     *
      * @param  Builder<self>  $query
      * @param  'asc'|'desc'  $direction
      * @return Builder<self>
      */
     public function scopeOrderByReceivedDate(Builder $query, Wallet $wallet, string $direction): Builder
     {
+        // this is to ensure that `addSelect` doesn't override the `select collections.*`
+        if (is_null($query->getQuery()->columns)) {
+            $query->select($this->qualifyColumn('*'));
+        }
+
         $query->leftJoin('nft_activity', function (JoinClause $join) use ($wallet) {
             $join->on('nft_activity.collection_id', '=', 'collections.id')
                 ->where('nft_activity.recipient', '=', $wallet->address);
         })
-            ->addSelect(DB::raw('MAX(nft_activity.timestamp) as received_at'));
+            ->addSelect(DB::raw('MAX(nft_activity.timestamp) as received_at'))
+            ->groupBy('collections.id');
 
         if ($direction === 'asc') {
             return $query->orderByRaw('received_at ASC NULLS FIRST');

--- a/app/Models/Collection.php
+++ b/app/Models/Collection.php
@@ -255,7 +255,7 @@ class Collection extends Model
     public function scopeOrderByReceivedDate(Builder $query, Wallet $wallet, string $direction): Builder
     {
         // this is to ensure that `addSelect` doesn't override the `select collections.*`
-        if (is_null($query->getQuery()->columns)) {
+        if (empty($query->getQuery()->columns)) {
             $query->select($this->qualifyColumn('*'));
         }
 
@@ -416,7 +416,7 @@ class Collection extends Model
             DB::raw(sprintf($extraAttributeSelect, 'opensea_slug', 'opensea_slug').' as opensea_slug'),
             // gets the website url with the same logic used on the `website` method
             DB::raw(sprintf('COALESCE(%s, CONCAT(networks.explorer_url, \'%s\', collections.address)) as website', sprintf($extraAttributeSelect, 'website', 'website'), '/token/')),
-            DB::raw('COUNT(nfts.id) as nfts_count'),
+            DB::raw('COUNT(DISTINCT nfts.id) as nfts_count'),
         ])->join(
             'networks',
             'networks.id',

--- a/app/Models/Collection.php
+++ b/app/Models/Collection.php
@@ -17,6 +17,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Query\Expression;
+use Illuminate\Database\Query\JoinClause;
 use Illuminate\Notifications\Notification;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\DB;
@@ -253,19 +254,17 @@ class Collection extends Model
      */
     public function scopeOrderByReceivedDate(Builder $query, Wallet $wallet, string $direction): Builder
     {
-        $select = sprintf("SELECT timestamp
-            FROM nft_activity
-            WHERE nft_activity.collection_id = collections.id
-            AND recipient = '%s'
-            ORDER BY timestamp desc
-            LIMIT 1
-        ", $wallet->address);
+        $query->leftJoin('nft_activity',  function (JoinClause $join) use ($wallet) {
+            $join->on('nft_activity.collection_id', '=', 'collections.id')
+                ->where('nft_activity.recipient', '=', $wallet->address);
+            })
+            ->addSelect(DB::raw('MAX(nft_activity.timestamp) as received_at'));
 
         if ($direction === 'asc') {
-            return $query->orderByRaw(sprintf('(%s) ASC NULLS FIRST', $select));
+            return $query->orderByRaw('received_at ASC NULLS FIRST');
         }
 
-        return $query->orderByRaw(sprintf('(%s) DESC NULLS LAST', $select));
+        return $query->orderByRaw('received_at DESC NULLS LAST');
     }
 
     /**


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->


## Summary
Closes: https://app.clickup.com/t/862kg3c7e

I used `dashbrd_demo_with_activities.dump` to test the query speed. Here is the result of the query changes:
The collections list query took around ~220ms to finish after the changes it is around ~110ms. Checkout the query and it's analayze result:



**Before:**
```SQL
select
	"collections"."id",
	"collections"."name",
	"collections"."slug",
	"collections"."address",
	"networks"."chain_id",
	"collections"."floor_price",
	(fiat_value->'USD')::numeric as floor_price_fiat,
	lower(tokens.symbol) as floor_price_currency,
	tokens.decimals as floor_price_decimals,
	case
		when collections.extra_attributes->>'image' = 'null' then null
		else collections.extra_attributes->>'image'
	end as image,
	case
		when collections.extra_attributes->>'banner' = 'null' then null
		else collections.extra_attributes->>'banner'
	end as banner,
	case
		when collections.extra_attributes->>'opensea_slug' = 'null' then null
		else collections.extra_attributes->>'opensea_slug'
	end as opensea_slug,
	coalesce(case
            when collections.extra_attributes->>'website' = 'null' then null
            else collections.extra_attributes->>'website'
        end, CONCAT(networks.explorer_url, '/token/', collections.address)) as website,
	COUNT(nfts.id) as nfts_count
from
	"collections"
inner join "networks" on
	"networks"."id" = "collections"."network_id"
left join "tokens" on
	"tokens"."id" = "collections"."floor_price_token_id"
left join "nfts" on
	"nfts"."collection_id" = "collections"."id"
left join "wallets" as "nft_wallets" on
	"nft_wallets"."id" = "nfts"."wallet_id"
where
	"collections"."id" in (
	select
		"collection_id"
	from
		"nfts"
	where
		"nfts"."wallet_id" in (
		select
			"id"
		from
			"wallets"
		where
			"wallets"."user_id" = 55
			and "wallets"."user_id" is not null
			and "wallets"."deleted_at" is null))
	and "nft_wallets"."user_id" = 55
	and 1 = 1
	and "collections"."network_id" in (1, 3)
	and "collections"."deleted_at" is null
group by
	"collections"."id",
	"networks"."id",
	"tokens"."id"
order by
	(
	select
		timestamp
	from
		nft_activity
	where
		nft_activity.collection_id = collections.id
		and recipient = '0x1544D2de126e3A4b194Cfad2a5C6966b3460ebE3'
	order by
		timestamp desc
	limit 1
        ) desc nulls last
```
```
Sort  (cost=222807.26..222916.99 rows=43892 width=319) (actual time=219.130..219.150 rows=73 loops=1)
  Sort Key: ((SubPlan 1)) DESC NULLS LAST
  Sort Method: quicksort  Memory: 52kB
  ->  GroupAggregate  (cost=1194.61..212968.82 rows=43892 width=319) (actual time=140.891..218.987 rows=73 loops=1)
        Group Key: collections.id, networks.id, tokens.id
        ->  Incremental Sort  (cost=1194.61..9419.67 rows=43892 width=1549) (actual time=140.770..211.393 rows=6079 loops=1)
              Sort Key: collections.id, networks.id, tokens.id
              Presorted Key: collections.id
              Full-sort Groups: 21  Sort Method: quicksort  Average Memory: 97kB  Peak Memory: 124kB
              Pre-sorted Groups: 34  Sort Method: quicksort  Average Memory: 904kB  Peak Memory: 2359kB
              ->  Nested Loop  (cost=1178.24..6455.62 rows=43892 width=1549) (actual time=127.565..204.203 rows=6079 loops=1)
                    Join Filter: (collections.id = nfts.collection_id)
                    Rows Removed by Join Filter: 437688
                    ->  Nested Loop Left Join  (cost=1177.80..1193.18 rows=466 width=1557) (actual time=121.997..122.915 rows=73 loops=1)
                          ->  Merge Join  (cost=1177.51..1180.17 rows=466 width=1547) (actual time=121.962..122.558 rows=73 loops=1)
                                Merge Cond: (collections.id = nfts_1.collection_id)
                                ->  Sort  (cost=252.31..253.84 rows=611 width=1531) (actual time=110.202..110.335 rows=611 loops=1)
                                      Sort Key: collections.id
                                      Sort Method: quicksort  Memory: 674kB
                                      ->  Hash Join  (cost=1.09..224.03 rows=611 width=1531) (actual time=108.718..109.622 rows=611 loops=1)
                                            Hash Cond: (collections.network_id = networks.id)
                                            ->  Seq Scan on collections  (cost=0.00..219.64 rows=611 width=1011) (actual time=108.657..109.307 rows=611 loops=1)
                                                  Filter: ((deleted_at IS NULL) AND (network_id = ANY ('{1,3}'::bigint[])))
                                            ->  Hash  (cost=1.04..1.04 rows=4 width=528) (actual time=0.035..0.037 rows=4 loops=1)
                                                  Buckets: 1024  Batches: 1  Memory Usage: 9kB
                                                  ->  Seq Scan on networks  (cost=0.00..1.04 rows=4 width=528) (actual time=0.026..0.028 rows=4 loops=1)
                                ->  Sort  (cost=925.20..925.21 rows=1 width=16) (actual time=11.732..11.795 rows=73 loops=1)
                                      Sort Key: nfts_1.collection_id
                                      Sort Method: quicksort  Memory: 29kB
                                      ->  Nested Loop  (cost=912.22..925.19 rows=1 width=16) (actual time=11.660..11.701 rows=73 loops=1)
                                            ->  Seq Scan on wallets nft_wallets  (cost=0.00..3.65 rows=1 width=8) (actual time=0.024..0.027 rows=1 loops=1)
                                                  Filter: (user_id = 55)
                                                  Rows Removed by Filter: 51
                                            ->  HashAggregate  (cost=912.22..916.88 rows=466 width=8) (actual time=11.632..11.659 rows=73 loops=1)
                                                  Group Key: nfts_1.collection_id
                                                  Batches: 1  Memory Usage: 49kB
                                                  ->  Merge Join  (cost=4.09..768.35 rows=57549 width=8) (actual time=1.990..9.647 rows=6079 loops=1)
                                                        Merge Cond: (nfts_1.wallet_id = wallets.id)
                                                        ->  Index Scan using nfts_wallet_id_index on nfts nfts_1  (cost=0.43..908975.18 rows=2992571 width=16) (actual time=0.016..7.301 rows=7971 loops=1)
                                                        ->  Sort  (cost=3.66..3.66 rows=1 width=8) (actual time=0.027..0.028 rows=1 loops=1)
                                                              Sort Key: wallets.id
                                                              Sort Method: quicksort  Memory: 25kB
                                                              ->  Seq Scan on wallets  (cost=0.00..3.65 rows=1 width=8) (actual time=0.021..0.021 rows=1 loops=1)
                                                                    Filter: ((user_id IS NOT NULL) AND (deleted_at IS NULL) AND (user_id = 55))
                                                                    Rows Removed by Filter: 51
                          ->  Memoize  (cost=0.29..0.69 rows=1 width=18) (actual time=0.002..0.002 rows=0 loops=73)
                                Cache Key: collections.floor_price_token_id
                                Cache Mode: logical
                                Hits: 71  Misses: 2  Evictions: 0  Overflows: 0  Memory Usage: 1kB
                                ->  Index Scan using tokens_pkey on tokens  (cost=0.28..0.68 rows=1 width=18) (actual time=0.011..0.011 rows=0 loops=2)
                                      Index Cond: (id = collections.floor_price_token_id)
                    ->  Memoize  (cost=0.44..1176.18 rows=416 width=24) (actual time=0.002..0.473 rows=6079 loops=73)
                          Cache Key: nft_wallets.id
                          Cache Mode: logical
                          Hits: 72  Misses: 1  Evictions: 0  Overflows: 0  Memory Usage: 333kB
                          ->  Index Scan using nfts_wallet_id_index on nfts  (cost=0.43..1176.17 rows=416 width=24) (actual time=0.018..6.088 rows=6079 loops=1)
                                Index Cond: (wallet_id = nft_wallets.id)
        SubPlan 1
          ->  Limit  (cost=0.56..4.58 rows=1 width=8) (actual time=0.016..0.016 rows=0 loops=73)
                ->  Index Only Scan Backward using nft_activity_collection_id_idx on nft_activity  (cost=0.56..4.58 rows=1 width=8) (actual time=0.014..0.014 rows=0 loops=73)
                      Index Cond: ((collection_id = collections.id) AND (recipient = '0x1544D2de126e3A4b194Cfad2a5C6966b3460ebE3'::citext))
                      Heap Fetches: 0
Planning Time: 4.413 ms
JIT:
  Functions: 72
  Options: Inlining false, Optimization false, Expressions true, Deforming true
  Timing: Generation 13.121 ms, Inlining 0.000 ms, Optimization 6.504 ms, Emission 100.983 ms, Total 120.608 ms
Execution Time: 233.088 ms
```

After:
```SQL
select
	"collections"."id",
	"collections"."name",
	"collections"."slug",
	"collections"."address",
	"networks"."chain_id",
	"collections"."floor_price",
	(fiat_value->'USD')::numeric as floor_price_fiat,
	lower(tokens.symbol) as floor_price_currency,
	tokens.decimals as floor_price_decimals,
	case
		when collections.extra_attributes->>'image' = 'null' then null
		else collections.extra_attributes->>'image'
	end as image,
	case
		when collections.extra_attributes->>'banner' = 'null' then null
		else collections.extra_attributes->>'banner'
	end as banner,
	case
		when collections.extra_attributes->>'opensea_slug' = 'null' then null
		else collections.extra_attributes->>'opensea_slug'
	end as opensea_slug,
	coalesce(case
            when collections.extra_attributes->>'website' = 'null' then null
            else collections.extra_attributes->>'website'
        end, CONCAT(networks.explorer_url, '/token/', collections.address)) as website,
	COUNT(distinct nfts.id) as nfts_count,
	MAX(nft_activity.timestamp) as received_at
from
	"collections"
inner join "networks" on
	"networks"."id" = "collections"."network_id"
left join "tokens" on
	"tokens"."id" = "collections"."floor_price_token_id"
left join "nfts" on
	"nfts"."collection_id" = "collections"."id"
left join "wallets" as "nft_wallets" on
	"nft_wallets"."id" = "nfts"."wallet_id"
left join "nft_activity" on
	"nft_activity"."collection_id" = "collections"."id"
	and "nft_activity"."recipient" = '0x1544D2de126e3A4b194Cfad2a5C6966b3460ebE3'
where
	"collections"."id" in (
	select
		"collection_id"
	from
		"nfts"
	where
		"nfts"."wallet_id" in (
		select
			"id"
		from
			"wallets"
		where
			"wallets"."user_id" = 55
			and "wallets"."user_id" is not null
			and "wallets"."deleted_at" is null))
	and "nft_wallets"."user_id" = 55
	and 1 = 1
	and "collections"."network_id" in (1, 3)
	and "collections"."deleted_at" is null
group by
	"collections"."id",
	"networks"."id",
	"tokens"."id"
order by
	received_at desc nulls last
```

```
Sort  (cost=24552.69..24662.42 rows=43892 width=319) (actual time=131.871..131.881 rows=73 loops=1)
  Sort Key: (max(nft_activity."timestamp")) DESC NULLS LAST
  Sort Method: quicksort  Memory: 52kB
  ->  GroupAggregate  (cost=1615.38..14714.25 rows=43892 width=319) (actual time=16.191..131.793 rows=73 loops=1)
        Group Key: collections.id, networks.id, tokens.id
        ->  Incremental Sort  (cost=1615.38..11971.00 rows=43892 width=1557) (actual time=16.133..126.608 rows=7728 loops=1)
              Sort Key: collections.id, networks.id, tokens.id
              Presorted Key: collections.id
              Full-sort Groups: 21  Sort Method: quicksort  Average Memory: 117kB  Peak Memory: 124kB
              Pre-sorted Groups: 44  Sort Method: quicksort  Average Memory: 2177kB  Peak Memory: 2393kB
              ->  Nested Loop  (cost=1594.43..9006.95 rows=43892 width=1557) (actual time=9.345..119.378 rows=7728 loops=1)
                    Join Filter: (collections.id = nfts.collection_id)
                    Rows Removed by Join Filter: 1025702
                    ->  Nested Loop Left Join  (cost=1593.99..3744.51 rows=466 width=1565) (actual time=6.200..7.464 rows=170 loops=1)
                          ->  Nested Loop Left Join  (cost=1593.43..1615.89 rows=466 width=1557) (actual time=6.190..6.561 rows=73 loops=1)
                                ->  Merge Join  (cost=1593.14..1595.80 rows=466 width=1547) (actual time=6.168..6.428 rows=73 loops=1)
                                      Merge Cond: (collections.id = nfts_1.collection_id)
                                      ->  Sort  (cost=252.31..253.84 rows=611 width=1531) (actual time=1.081..1.171 rows=611 loops=1)
                                            Sort Key: collections.id
                                            Sort Method: quicksort  Memory: 674kB
                                            ->  Hash Join  (cost=1.09..224.03 rows=611 width=1531) (actual time=0.051..0.652 rows=611 loops=1)
                                                  Hash Cond: (collections.network_id = networks.id)
                                                  ->  Seq Scan on collections  (cost=0.00..219.64 rows=611 width=1011) (actual time=0.025..0.463 rows=611 loops=1)
                                                        Filter: ((deleted_at IS NULL) AND (network_id = ANY ('{1,3}'::bigint[])))
                                                  ->  Hash  (cost=1.04..1.04 rows=4 width=528) (actual time=0.015..0.016 rows=4 loops=1)
                                                        Buckets: 1024  Batches: 1  Memory Usage: 9kB
                                                        ->  Seq Scan on networks  (cost=0.00..1.04 rows=4 width=528) (actual time=0.008..0.011 rows=4 loops=1)
                                      ->  Sort  (cost=1340.83..1340.84 rows=1 width=16) (actual time=5.075..5.103 rows=73 loops=1)
                                            Sort Key: nfts_1.collection_id
                                            Sort Method: quicksort  Memory: 29kB
                                            ->  Nested Loop  (cost=1327.85..1340.82 rows=1 width=16) (actual time=5.027..5.051 rows=73 loops=1)
                                                  ->  Seq Scan on wallets nft_wallets  (cost=0.00..3.65 rows=1 width=8) (actual time=0.020..0.021 rows=1 loops=1)
                                                        Filter: (user_id = 55)
                                                        Rows Removed by Filter: 51
                                                  ->  HashAggregate  (cost=1327.85..1332.51 rows=466 width=8) (actual time=5.004..5.019 rows=73 loops=1)
                                                        Group Key: nfts_1.collection_id
                                                        Batches: 1  Memory Usage: 49kB
                                                        ->  Nested Loop  (cost=0.43..1183.98 rows=57549 width=8) (actual time=0.035..4.084 rows=6079 loops=1)
                                                              ->  Seq Scan on wallets  (cost=0.00..3.65 rows=1 width=8) (actual time=0.012..0.013 rows=1 loops=1)
                                                                    Filter: ((user_id IS NOT NULL) AND (deleted_at IS NULL) AND (user_id = 55))
                                                                    Rows Removed by Filter: 51
                                                              ->  Index Scan using nfts_wallet_id_index on nfts nfts_1  (cost=0.43..1176.17 rows=416 width=16) (actual time=0.020..3.274 rows=6079 loops=1)
                                                                    Index Cond: (wallet_id = wallets.id)
                                ->  Memoize  (cost=0.29..4.24 rows=1 width=18) (actual time=0.001..0.001 rows=0 loops=73)
                                      Cache Key: collections.floor_price_token_id
                                      Cache Mode: logical
                                      Hits: 71  Misses: 2  Evictions: 0  Overflows: 0  Memory Usage: 1kB
                                      ->  Index Scan using tokens_pkey on tokens  (cost=0.28..4.23 rows=1 width=18) (actual time=0.008..0.008 rows=0 loops=2)
                                            Index Cond: (id = collections.floor_price_token_id)
                          ->  Index Only Scan using nft_activity_collection_id_idx on nft_activity  (cost=0.56..4.56 rows=1 width=16) (actual time=0.007..0.010 rows=1 loops=73)
                                Index Cond: ((collection_id = collections.id) AND (recipient = '0x1544D2de126e3A4b194Cfad2a5C6966b3460ebE3'::citext))
                                Heap Fetches: 0
                    ->  Memoize  (cost=0.44..1176.18 rows=416 width=24) (actual time=0.001..0.241 rows=6079 loops=170)
                          Cache Key: nft_wallets.id
                          Cache Mode: logical
                          Hits: 169  Misses: 1  Evictions: 0  Overflows: 0  Memory Usage: 333kB
                          ->  Index Scan using nfts_wallet_id_index on nfts  (cost=0.43..1176.17 rows=416 width=24) (actual time=0.011..3.544 rows=6079 loops=1)
                                Index Cond: (wallet_id = nft_wallets.id)
Planning Time: 5.143 ms
Execution Time: 132.266 ms
```

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
