### PR TITLE
feat: dark mode for my collections page

### DIFF
--- a/resources/css/_tables.css
+++ b/resources/css/_tables.css
@@ -53,12 +53,12 @@
 
 .table-list thead tr th:first-child::before {
     content: "";
-    @apply pointer-events-none absolute left-0 top-0 z-10 -ml-3 block h-full w-3 rounded-l-xl bg-theme-secondary-50;
+    @apply pointer-events-none absolute left-0 top-0 z-10 -ml-3 block h-full w-3 rounded-l-xl bg-theme-secondary-50 dark:dark:bg-theme-dark-950;
 }
 
 .table-list thead tr th:last-child::after {
     content: "";
-    @apply pointer-events-none absolute right-0 top-0 z-10 -mr-3 block h-full w-3 rounded-r-xl bg-theme-secondary-50;
+    @apply pointer-events-none absolute right-0 top-0 z-10 -mr-3 block h-full w-3 rounded-r-xl bg-theme-secondary-50 dark:dark:bg-theme-dark-950;
 }
 
 .table-list tbody tr {
@@ -67,7 +67,7 @@
 
 .table-list tbody tr::after {
     content: "";
-    @apply transition-default pointer-events-none absolute inset-0 -mx-3 rounded-xl outline outline-3 outline-transparent;
+    @apply transition-default pointer-events-none absolute inset-0 -mx-3 rounded-xl outline outline-3 outline-transparent dark:hover:outline-theme-dark-500;
 }
 
 .table-list tbody tr:hover::after {
@@ -77,12 +77,12 @@
 
 .table-list tbody tr td:first-child::before {
     content: "";
-    @apply pointer-events-none absolute left-0 top-0 z-10 -ml-3 block h-full w-3 rounded-l-xl border-y border-l border-theme-secondary-300;
+    @apply pointer-events-none absolute left-0 top-0 z-10 -ml-3 block h-full w-3 rounded-l-xl border-y border-l border-theme-secondary-300 dark:border-theme-dark-700;
 }
 
 .table-list tbody tr td:last-child::before {
     content: "";
-    @apply pointer-events-none absolute right-0 top-0 z-10 -mr-3 block h-full w-3 rounded-r-xl border-y border-r border-theme-secondary-300;
+    @apply pointer-events-none absolute right-0 top-0 z-10 -mr-3 block h-full w-3 rounded-r-xl border-y border-r border-theme-secondary-300 dark:border-theme-dark-700;
 }
 
 .table-list tbody > tr,
@@ -92,5 +92,5 @@
 
 .table-list tbody tr td.custom-table-cell:after {
     content: "";
-    @apply pointer-events-none absolute top-0 z-10 block h-full w-full border-y border-theme-secondary-300;
+    @apply pointer-events-none absolute top-0 z-10 block h-full w-full border-y border-theme-secondary-300 dark:border-theme-dark-700;
 }

--- a/resources/js/Components/Collections/CollectionActions/CollectionActions.tsx
+++ b/resources/js/Components/Collections/CollectionActions/CollectionActions.tsx
@@ -13,7 +13,7 @@ interface ActionProperties extends Omit<React.HTMLProps<HTMLButtonElement>, "typ
 const Action = ({ ...properties }: ActionProperties): JSX.Element => (
     <button
         type="button"
-        className="transition-default block w-full whitespace-nowrap rounded-sm px-6 py-2.5 text-left text-base font-medium text-theme-secondary-700 outline-none outline-3 outline-offset-[-3px]  focus-visible:outline-theme-primary-300 enabled:cursor-pointer enabled:hover:bg-theme-secondary-100 enabled:hover:text-theme-secondary-900 disabled:text-theme-secondary-500"
+        className="transition-default block w-full whitespace-nowrap rounded-sm px-6 py-2.5 text-left text-base font-medium text-theme-secondary-700 outline-none outline-3 outline-offset-[-3px]  focus-visible:outline-theme-primary-300 enabled:cursor-pointer enabled:hover:bg-theme-secondary-100 enabled:hover:text-theme-secondary-900 disabled:text-theme-secondary-500 dark:text-theme-dark-200 dark:hover:bg-theme-dark-700 dark:hover:text-theme-dark-50 dark:disabled:text-theme-dark-400 dark:disabled:hover:bg-theme-dark-900"
         {...properties}
     />
 );
@@ -108,7 +108,7 @@ export const CollectionActions = ({
 
                 <Dropdown.Content
                     className="-z-1 w-full px-6 sm:w-auto sm:px-0"
-                    contentClasses="shadow-3xl flex w-full select-none flex-col rounded-xl bg-white py-3.5 sm:w-auto"
+                    contentClasses="shadow-3xl flex w-full select-none flex-col rounded-xl bg-white py-3.5 sm:w-auto dark:bg-theme-dark-900 dark:border dark:border-theme-dark-700"
                 >
                     {({ setOpen }) => (
                         <div data-testid="CollectionActions__popup">

--- a/resources/js/Components/Collections/CollectionCard/CollectionCard.tsx
+++ b/resources/js/Components/Collections/CollectionCard/CollectionCard.tsx
@@ -54,7 +54,7 @@ export const CollectionCard = ({
         <div
             ref={reference}
             data-testid="CollectionCard"
-            className="transition-default group relative flex cursor-pointer flex-col rounded-xl border border-theme-secondary-300 p-8 outline outline-3 outline-transparent hover:outline-theme-primary-100 focus-visible:outline-theme-primary-300"
+            className="transition-default group relative flex cursor-pointer flex-col rounded-xl border border-theme-secondary-300 p-8 outline outline-3 outline-transparent hover:outline-theme-primary-100 focus-visible:outline-theme-primary-300 dark:border-theme-dark-700 dark:hover:outline-theme-dark-500 dark:focus-visible:outline-theme-dark-400"
             onClick={() => {
                 router.visit(
                     route("collections.view", {
@@ -67,7 +67,7 @@ export const CollectionCard = ({
                 <CollectionActions
                     collection={collection}
                     isHidden={isHidden}
-                    buttonClassName="border-4 border-white hover:border-theme-secondary-300 active:border-theme-secondary-400"
+                    buttonClassName="border-4 border-white hover:border-theme-secondary-300 active:border-theme-secondary-400 dark:border-theme-dark-900 dark:bg-theme-dark-900 dark:active:bg-theme-secondary-400"
                     reportAvailableIn={reportAvailableIn}
                     alreadyReported={alreadyReported}
                     reportReasons={reportReasons}
@@ -83,14 +83,14 @@ export const CollectionCard = ({
             <div className="relative mx-auto -mt-11 flex items-center justify-center">
                 <div className="flex h-[5.5rem] w-[5.5rem] items-center justify-center rounded-full backdrop-blur-md">
                     <Img
-                        className="aspect-square h-20 w-20 rounded-full bg-theme-secondary-100 object-cover"
+                        className="aspect-square h-20 w-20 rounded-full bg-theme-secondary-100 object-cover dark:bg-theme-dark-700"
                         src={collection.image ?? undefined}
                         data-testid="CollectionCard__image"
                         isCircle
                     />
                 </div>
 
-                <div className="absolute left-[3.875rem] top-[3.875rem] h-5 w-5 rounded-full ring-4 ring-white">
+                <div className="absolute left-[3.875rem] top-[3.875rem] h-5 w-5 rounded-full ring-4 ring-white dark:ring-theme-dark-900">
                     <NetworkIcon networkId={collection.chainId} />
                 </div>
             </div>
@@ -101,7 +101,7 @@ export const CollectionCard = ({
             >
                 <span
                     ref={collectionNameReference}
-                    className="break-word-legacy group-hover mx-auto mt-1 max-w-full truncate text-lg font-medium leading-7 group-hover:text-theme-primary-700"
+                    className="break-word-legacy group-hover mx-auto mt-1 max-w-full truncate text-lg font-medium leading-7 group-hover:text-theme-primary-700 dark:text-theme-dark-50 dark:group-hover:text-theme-primary-400"
                 >
                     {collection.name}
                 </span>
@@ -110,14 +110,14 @@ export const CollectionCard = ({
             <div className="mt-3 flex">
                 <div className="flex flex-1 justify-end">
                     <div className="ml-auto flex flex-col space-y-0.5 font-medium">
-                        <span className="whitespace-nowrap text-sm leading-5.5 text-theme-secondary-500">
+                        <span className="whitespace-nowrap text-sm leading-5.5 text-theme-secondary-500 dark:text-theme-dark-300">
                             {t("pages.collections.floor_price")}
                         </span>
 
                         {collection.floorPrice === null ? (
                             <span
                                 data-testid="CollectionCard__unknown-floor-price"
-                                className="text-sm font-medium text-theme-secondary-300"
+                                className="text-sm font-medium text-theme-secondary-300 dark:text-theme-dark-700"
                             >
                                 {t("common.na")}
                             </span>
@@ -131,11 +131,11 @@ export const CollectionCard = ({
                     </div>
                 </div>
 
-                <div className="mx-6 border-l border-theme-secondary-300" />
+                <div className="mx-6 border-l border-theme-secondary-300 dark:border-theme-dark-700" />
 
                 <div className="flex flex-1 flex-col font-medium">
                     <div className="mr-auto flex flex-col space-y-0.5 font-medium">
-                        <span className="whitespace-nowrap text-sm leading-5.5 text-theme-secondary-500">
+                        <span className="whitespace-nowrap text-sm leading-5.5 text-theme-secondary-500 dark:text-theme-dark-300">
                             {t("pages.collections.value")}
                         </span>
 
@@ -143,7 +143,7 @@ export const CollectionCard = ({
                             {collection.floorPrice === null ? (
                                 <span
                                     data-testid="CollectionCard__unknown-value"
-                                    className="text-sm font-medium text-theme-secondary-300"
+                                    className="text-sm font-medium text-theme-secondary-300 dark:text-theme-dark-700"
                                 >
                                     {t("common.na")}
                                 </span>

--- a/resources/js/Components/Collections/CollectionFloorPrice/CollectionFloorPrice.tsx
+++ b/resources/js/Components/Collections/CollectionFloorPrice/CollectionFloorPrice.tsx
@@ -32,7 +32,8 @@ export const CollectionFloorPrice = ({
             <div
                 data-testid="CollectionFloorPrice__crypto"
                 className={cn("text-sm leading-5.5 md:text-base md:leading-6", {
-                    "text-theme-secondary-700": variant === "list",
+                    "text-theme-secondary-700 dark:text-theme-dark-200": variant === "list",
+                    "dark:text-theme-dark-50": variant === "grid",
                 })}
             >
                 <FormatCrypto
@@ -42,7 +43,7 @@ export const CollectionFloorPrice = ({
             </div>
 
             {variant === "list" && (
-                <div className="text-sm text-theme-secondary-500">
+                <div className="text-sm text-theme-secondary-500 dark:text-theme-dark-300">
                     {fiatValue != null && isTruthy(user) && (
                         <span data-testid="CollectionFloorPrice__fiat">
                             <FormatFiat

--- a/resources/js/Components/Collections/CollectionName/CollectionName.tsx
+++ b/resources/js/Components/Collections/CollectionName/CollectionName.tsx
@@ -42,7 +42,7 @@ export const CollectionName = ({
                         <p
                             ref={collectionNameReference}
                             data-testid="CollectionName__name"
-                            className="group-hover md:leading-auto truncate text-sm font-medium leading-6 text-theme-secondary-900 group-hover:text-theme-primary-700 md:text-lg"
+                            className="group-hover md:leading-auto truncate text-sm font-medium leading-6 text-theme-secondary-900 group-hover:text-theme-primary-700 dark:text-theme-dark-50 dark:group-hover:text-theme-primary-400 md:text-lg"
                         >
                             {collection.name}
                         </p>

--- a/resources/js/Components/Collections/CollectionPortfolioValue/CollectionPortfolioValue.tsx
+++ b/resources/js/Components/Collections/CollectionPortfolioValue/CollectionPortfolioValue.tsx
@@ -28,7 +28,7 @@ export const CollectionPortfolioValue = ({
             })}
         >
             <div
-                className="text-sm leading-5.5 text-theme-secondary-900 md:text-base md:leading-6"
+                className="text-sm leading-5.5 text-theme-secondary-900 dark:text-theme-dark-50 md:text-base md:leading-6"
                 data-testid="CollectionPortfolioValue__crypto"
             >
                 <FormatCrypto
@@ -39,7 +39,7 @@ export const CollectionPortfolioValue = ({
 
             {variant === "list" && (
                 <div
-                    className="text-xs leading-4.5 text-theme-secondary-500 md:text-sm md:leading-5.5"
+                    className="text-xs leading-4.5 text-theme-secondary-500 dark:text-theme-dark-300 md:text-sm md:leading-5.5"
                     data-testid="CollectionPortfolioValue__fiat"
                 >
                     {isTruthy(convertedValue) && (

--- a/resources/js/Components/Collections/CollectionsTable/CollectionsTableItem.tsx
+++ b/resources/js/Components/Collections/CollectionsTable/CollectionsTableItem.tsx
@@ -57,7 +57,7 @@ export const CollectionsTableItem = ({
             ref={reference}
             key={uniqueKey}
             borderClass=""
-            className="group cursor-pointer"
+            className="group cursor-pointer dark:border-theme-dark-700"
             onClick={() => {
                 router.visit(
                     route("collections.view", {
@@ -87,7 +87,7 @@ export const CollectionsTableItem = ({
                     {collection.floorPrice === null || user === null ? (
                         <span
                             data-testid="CollectionsTableItem__unknown-floor-price"
-                            className="text-sm font-medium text-theme-secondary-500"
+                            className="text-sm font-medium text-theme-secondary-500 dark:text-theme-dark-300"
                         >
                             {t("common.na")}
                         </span>
@@ -111,7 +111,7 @@ export const CollectionsTableItem = ({
                 {collection.floorPrice === null || user === null ? (
                     <span
                         data-testid="CollectionsTableItem__unknown-value"
-                        className="text-sm font-medium text-theme-secondary-500"
+                        className="text-sm font-medium text-theme-secondary-500 dark:text-theme-dark-300"
                     >
                         {t("common.na")}
                     </span>

--- a/resources/js/Components/Table/TableHeader.tsx
+++ b/resources/js/Components/Table/TableHeader.tsx
@@ -29,7 +29,8 @@ export const TableHeader = <RowDataType extends Record<never, unknown>>({
         const thElementClassName = cn(
             "group relative text-sm text-left select-none border-theme-secondary-300 m-0 font-medium",
             {
-                "bg-theme-secondary-50 text-theme-secondary-700": variant === "default" || variant === "list",
+                "bg-theme-secondary-50 text-theme-secondary-700 dark:bg-theme-dark-950 dark:text-theme-dark-200":
+                    variant === "default" || variant === "list",
                 "text-theme-secondary-500": variant === "borderless",
             },
             column.headerClassName,

--- a/resources/js/Components/Tabs.tsx
+++ b/resources/js/Components/Tabs.tsx
@@ -36,9 +36,11 @@ const getTabClasses = ({
             baseClassName,
             "grow sm:grow-0 justify-center select-none rounded-full w-10 h-10 flex items-center justify-center text-sm -outline-offset-[3px]",
             {
-                "border-transparent bg-white text-theme-secondary-900 shadow-sm": selected,
-                "active:bg-theme-secondary-200 hover:bg-theme-secondary-300": !selected && !disabled,
-                "cursor-not-allowed focus:bg-transparent active:bg-transparent": disabled,
+                "border-transparent bg-white text-theme-secondary-900 shadow-sm dark:bg-theme-dark-800 dark:text-theme-dark-50":
+                    selected,
+                "active:bg-theme-secondary-200 hover:bg-theme-secondary-300 dark:hover:bg-theme-dark-900 dark:hover:text-theme-dark-200":
+                    !selected && !disabled,
+                "cursor-not-allowed focus:bg-transparent active:bg-transparent dark:text-theme-dark-400": disabled,
             },
             className,
         );

--- a/resources/js/Pages/Collections/Components/CollectionsFilter/CollectionsSorting.tsx
+++ b/resources/js/Pages/Collections/Components/CollectionsFilter/CollectionsSorting.tsx
@@ -55,7 +55,7 @@ export const CollectionsSorting = ({
 
             <Dropdown.Content
                 className="left-0 right-0 z-10 w-full origin-top-right px-6 sm:left-auto sm:mt-2 sm:h-fit sm:w-48 sm:px-0"
-                contentClasses="shadow-3xl flex w-full select-none flex-col overflow-hidden rounded-xl bg-white py-3.5 dark:bg-theme-dark-900 dark:border dark:bordar-theme-dark-700"
+                contentClasses="shadow-3xl flex w-full select-none flex-col overflow-hidden rounded-xl bg-white py-3.5 dark:bg-theme-dark-900 dark:border dark:border-theme-dark-700"
             >
                 <DropdownButton
                     isActive={activeSort === "received"}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[general] Dark Mode](https://app.clickup.com/t/862kf8har): [[general] grid toggle dark mode](https://app.clickup.com/t/862kf8e3w) & [[collections] list dark mode](https://app.clickup.com/t/862kf8e70)

## Summary

- Dark mode has been enabled for the entire `My collections` page and all its children components.
- Both grid and table collection views now support dark mode.
- `Table` component styles have been updated to support dark mode.

## Steps to reproduce

1. Run the app in `local` or `testing_e2e` mode.
2. Go to `Settings` and turn on the `Dark mode` slider.
3. Go to `/collections` page.
4. Navigate in the page and see the magic ✨ 


https://github.com/ArdentHQ/dashbrd/assets/55117912/27987e6b-db30-45fb-a775-fd17d5cf6d89



## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
