### PR TITLE
feat: dark mode for my wallet page

### DIFF
--- a/resources/js/Components/BalanceHeader/BalanceHeader.skeleton.tsx
+++ b/resources/js/Components/BalanceHeader/BalanceHeader.skeleton.tsx
@@ -11,12 +11,14 @@ export const BalanceHeaderSkeleton = ({ animated }: { animated: boolean }): JSX.
         <>
             <div
                 data-testid="BalanceHeaderSkeleton"
-                className="hidden items-center justify-between whitespace-nowrap rounded-xl border border-theme-secondary-300 px-6 py-4 sm:block xl:flex"
+                className="hidden items-center justify-between whitespace-nowrap rounded-xl border border-theme-secondary-300 px-6 py-4 dark:border-theme-dark-700 sm:block xl:flex"
             >
-                <div className="flex w-auto justify-between pb-3 xl:justify-start xl:divide-x  xl:divide-theme-secondary-300 xl:pb-0">
-                    <div className="flex divide-x divide-theme-secondary-300 font-medium">
+                <div className="flex w-auto justify-between pb-3 xl:justify-start xl:divide-x xl:divide-theme-secondary-300 xl:pb-0 dark:xl:divide-theme-dark-700">
+                    <div className="flex divide-x divide-theme-secondary-300 font-medium dark:xl:divide-theme-dark-700">
                         <div className="pr-4">
-                            <div className="text-sm text-theme-secondary-500">{t("common.my_balance")}</div>
+                            <div className="text-sm text-theme-secondary-500 dark:text-theme-dark-300">
+                                {t("common.my_balance")}
+                            </div>
                             <Skeleton
                                 className="mt-1 h-6"
                                 width={91}
@@ -25,7 +27,9 @@ export const BalanceHeaderSkeleton = ({ animated }: { animated: boolean }): JSX.
                         </div>
 
                         <div className="px-4">
-                            <div className="text-sm text-theme-secondary-500">{t("common.tokens")}</div>
+                            <div className="text-sm text-theme-secondary-500 dark:text-theme-dark-300">
+                                {t("common.tokens")}
+                            </div>
                             <Skeleton
                                 className="mt-1 h-6"
                                 width={30}
@@ -35,7 +39,7 @@ export const BalanceHeaderSkeleton = ({ animated }: { animated: boolean }): JSX.
                     </div>
 
                     <div className="pl-4 font-medium">
-                        <div className="text-right text-sm text-theme-secondary-500 xl:text-left">
+                        <div className="text-right text-sm text-theme-secondary-500 dark:text-theme-dark-300 xl:text-left">
                             {t("common.my_address")}
                         </div>
 
@@ -159,13 +163,14 @@ export const BalanceHeaderSkeleton = ({ animated }: { animated: boolean }): JSX.
                             </div>
                         </div>
 
-                        <div className="ml-4 flex pl-4 text-sm xl:border-l xl:border-theme-secondary-300">
+                        <div className="ml-4 flex pl-4 text-sm xl:border-l xl:border-theme-secondary-300 dark:xl:border-theme-dark-700">
                             <LinkButton
                                 data-testid="BalanceHeader__more-details"
                                 className={cn(
                                     "transition-default rounded-full text-sm font-medium leading-5.5 text-theme-primary-600 underline decoration-transparent underline-offset-2 outline-none",
                                     "hover:text-theme-primary-700 hover:decoration-theme-primary-700",
                                     "outline-offset-4 focus-visible:outline-3 focus-visible:outline-theme-primary-300",
+                                    "dark:text-theme-primary-400 dark:hover:text-theme-primary-500 dark:hover:decoration-theme-primary-500",
                                 )}
                             >
                                 {t("common.more_details")}

--- a/resources/js/Components/BalanceHeader/BalanceHeader.tsx
+++ b/resources/js/Components/BalanceHeader/BalanceHeader.tsx
@@ -49,13 +49,15 @@ export const BalanceHeader = ({
         <>
             <div
                 data-testid="BalanceHeader"
-                className="hidden items-center justify-between whitespace-nowrap rounded-xl border border-theme-secondary-300 px-6 py-4 sm:block xl:flex"
+                className="hidden items-center justify-between whitespace-nowrap rounded-xl border border-theme-secondary-300 px-6 py-4 dark:border-theme-dark-700 sm:block xl:flex"
             >
-                <div className="flex w-auto justify-between xl:justify-start xl:divide-x xl:divide-theme-secondary-300">
-                    <div className="flex divide-x divide-theme-secondary-300 font-medium">
+                <div className="flex w-auto justify-between xl:justify-start xl:divide-x xl:divide-theme-secondary-300 dark:xl:divide-theme-dark-700">
+                    <div className="flex divide-x divide-theme-secondary-300 font-medium dark:divide-theme-dark-700">
                         <div className="pr-4">
-                            <div className="text-sm text-theme-secondary-500">{t("common.my_balance")}</div>
-                            <div className="text-lg text-theme-secondary-900">
+                            <div className="text-sm text-theme-secondary-500 dark:text-theme-dark-300">
+                                {t("common.my_balance")}
+                            </div>
+                            <div className="text-lg text-theme-secondary-900 dark:text-theme-dark-50">
                                 <DynamicBalance
                                     balance={balance}
                                     currency={currency}
@@ -64,17 +66,19 @@ export const BalanceHeader = ({
                         </div>
 
                         <div className="px-4">
-                            <div className="text-sm text-theme-secondary-500">{t("common.tokens")}</div>
-                            <div className="text-lg text-theme-secondary-900">{tokens}</div>
+                            <div className="text-sm text-theme-secondary-500 dark:text-theme-dark-300">
+                                {t("common.tokens")}
+                            </div>
+                            <div className="text-lg text-theme-secondary-900 dark:text-theme-dark-50">{tokens}</div>
                         </div>
                     </div>
 
                     <div className="pl-4 font-medium">
-                        <div className="text-right text-sm text-theme-secondary-500 xl:text-left">
+                        <div className="text-right text-sm text-theme-secondary-500 dark:text-theme-dark-300 xl:text-left">
                             {t("common.my_address")}
                         </div>
 
-                        <div className="flex items-center text-right text-lg text-theme-secondary-900 xl:text-left">
+                        <div className="flex items-center text-right text-lg text-theme-secondary-900 dark:text-theme-dark-50  xl:text-left">
                             <TruncateMiddle
                                 length={16}
                                 text={address}
@@ -106,7 +110,7 @@ export const BalanceHeader = ({
                             />
                         </div>
 
-                        <div className="ml-4 flex pl-4 text-sm xl:border-l xl:border-theme-secondary-300">
+                        <div className="ml-4 flex pl-4 text-sm xl:border-l xl:border-theme-secondary-300 dark:xl:border-theme-dark-700">
                             <LinkButton
                                 data-testid="BalanceHeader__more-details"
                                 onClick={() => {
@@ -118,6 +122,7 @@ export const BalanceHeader = ({
                                     "outline-none outline-3 outline-offset-4",
                                     "hover:text-theme-primary-700 hover:decoration-theme-primary-700",
                                     "focus-visible:outline-theme-primary-300",
+                                    "dark:text-theme-primary-400 dark:hover:text-theme-primary-500 dark:hover:decoration-theme-primary-500",
                                 )}
                             >
                                 {t("common.more_details")}

--- a/resources/js/Components/BalanceHeader/BalanceHeaderMobile.skeleton.tsx
+++ b/resources/js/Components/BalanceHeader/BalanceHeaderMobile.skeleton.tsx
@@ -9,10 +9,12 @@ export const BalanceHeaderMobileSkeleton = ({ animated }: { animated: boolean })
 
     return (
         <div data-testid="BalanceHeaderMobileSkeleton">
-            <div className="-mx-6 -mt-6 mb-6 flex bg-theme-secondary-50 px-6 py-2.5">
+            <div className="-mx-6 -mt-6 mb-6 flex bg-theme-secondary-50 px-6 py-2.5 dark:bg-theme-dark-950">
                 <div className="flex w-full items-center justify-between">
                     <div className="flex text-sm font-medium">
-                        <span className="mr-1 text-theme-secondary-700">{t("common.my_address")}:</span>
+                        <span className="mr-1 text-theme-secondary-700 dark:text-theme-dark-200">
+                            {t("common.my_address")}:
+                        </span>
                         <Skeleton
                             height={15}
                             width={100}
@@ -30,7 +32,9 @@ export const BalanceHeaderMobileSkeleton = ({ animated }: { animated: boolean })
 
             <div className="flex flex-col items-center space-y-4 text-center">
                 <div>
-                    <div className="text-sm font-medium text-theme-secondary-500">{t("common.my_balance")}</div>
+                    <div className="text-sm font-medium text-theme-secondary-500 dark:text-theme-dark-300">
+                        {t("common.my_balance")}
+                    </div>
                     <div className="text-2xl font-medium text-theme-secondary-900">
                         <Skeleton
                             height={32}
@@ -69,7 +73,7 @@ export const BalanceHeaderMobileSkeleton = ({ animated }: { animated: boolean })
 
                 <div className="mt-2 flex items-center justify-between">
                     <div className="flex space-x-2">
-                        <p className="text-sm font-medium leading-5.5 text-theme-secondary-700">
+                        <p className="text-sm font-medium leading-5.5 text-theme-secondary-700 dark:text-theme-dark-200">
                             {t("common.tokens")}:
                         </p>
 
@@ -86,6 +90,7 @@ export const BalanceHeaderMobileSkeleton = ({ animated }: { animated: boolean })
                             "transition-default rounded-sm border-b border-transparent text-sm font-medium leading-none text-theme-primary-600 outline-none ",
                             "hover:border-theme-primary-700 hover:text-theme-primary-700",
                             "focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-theme-primary-300 focus-visible:ring-offset-2",
+                            "dark:text-theme-primary-400 dark:hover:text-theme-primary-500 dark:hover:decoration-theme-primary-500",
                         )}
                     >
                         {t("common.more_details")}

--- a/resources/js/Components/BalanceHeader/BalanceHeaderMobile.tsx
+++ b/resources/js/Components/BalanceHeader/BalanceHeaderMobile.tsx
@@ -30,11 +30,13 @@ export const BalanceHeaderMobile = ({
 
     return (
         <div data-testid="BalanceHeaderMobile">
-            <div className="-mx-6 -mt-6 mb-6 flex bg-theme-secondary-50 px-6 py-2.5">
+            <div className="-mx-6 -mt-6 mb-6 flex bg-theme-secondary-50 px-6 py-2.5 dark:bg-theme-dark-950">
                 <div className="flex w-full items-center justify-between">
                     <div className="text-sm font-medium">
-                        <span className="mr-1 text-theme-secondary-700">{t("common.my_address")}:</span>
-                        <span>
+                        <span className="mr-1 text-theme-secondary-700 dark:text-theme-dark-200">
+                            {t("common.my_address")}:
+                        </span>
+                        <span className="dark:text-theme-dark-50">
                             <TruncateMiddle
                                 length={10}
                                 text={address}
@@ -45,7 +47,7 @@ export const BalanceHeaderMobile = ({
                     <Clipboard text={address}>
                         <button type="button">
                             <Icon
-                                className="text-theme-primary-600"
+                                className="text-theme-primary-600 dark:text-theme-primary-400"
                                 name="Copy"
                                 size="md"
                             />
@@ -56,8 +58,10 @@ export const BalanceHeaderMobile = ({
 
             <div className="flex flex-col items-center space-y-4">
                 <div className="space-y-0.5 text-center font-medium">
-                    <p className="text-sm leading-5.5 text-theme-secondary-500">{t("common.my_balance")}</p>
-                    <p className="text-2xl text-theme-secondary-900">
+                    <p className="text-sm leading-5.5 text-theme-secondary-500 dark:text-theme-dark-300">
+                        {t("common.my_balance")}
+                    </p>
+                    <p className="text-2xl text-theme-secondary-900 dark:text-theme-dark-50">
                         <FormatFiat
                             value={balance}
                             currency={currency}
@@ -76,8 +80,9 @@ export const BalanceHeaderMobile = ({
                 <PortfolioBreakdownLine assets={assets} />
 
                 <div className="mt-2 flex items-center justify-between">
-                    <p className="text-sm font-medium leading-5.5 text-theme-secondary-700">
-                        {t("common.tokens")}: <span className="text-theme-secondary-900">{assets.length}</span>
+                    <p className="text-sm font-medium leading-5.5 text-theme-secondary-700 dark:text-theme-dark-200">
+                        {t("common.tokens")}:{" "}
+                        <span className="text-theme-secondary-900 dark:text-theme-dark-50">{assets.length}</span>
                     </p>
 
                     <LinkButton
@@ -89,6 +94,7 @@ export const BalanceHeaderMobile = ({
                             "transition-default rounded-sm border-b border-transparent text-sm font-medium leading-none text-theme-primary-600 outline-none ",
                             "hover:border-theme-primary-700 hover:text-theme-primary-700",
                             "focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-theme-primary-300 focus-visible:ring-offset-2",
+                            "dark:text-theme-primary-400 dark:hover:text-theme-primary-500 dark:hover:decoration-theme-primary-500",
                         )}
                     >
                         {t("common.more_details")}

--- a/resources/js/Components/Collections/CollectionActivityTable/CollectionActivityTable.blocks.tsx
+++ b/resources/js/Components/Collections/CollectionActivityTable/CollectionActivityTable.blocks.tsx
@@ -713,7 +713,7 @@ export const CollectionActivityTableItem = ({
         <TableRow
             data-testid="ActivityTable__Row"
             borderClass={cn(
-                "group border-b border-theme-secondary-300 border-dashed",
+                "group border-b border-theme-secondary-300 border-dashed dark:border-theme-dark-700",
                 hasBorderBottom ? "last:border-b-[5px] last:border-solid" : "last:border-b-0",
             )}
         >

--- a/resources/js/Components/Graphs/DonutGraph/DonutGraph.tsx
+++ b/resources/js/Components/Graphs/DonutGraph/DonutGraph.tsx
@@ -24,7 +24,7 @@ export const DonutGraph = ({ data, size, renderTooltip, children }: DonutGraphPr
                     {...circleProperties}
                     id={`circleTrackLine__${index}`}
                     data-testid="DonutGraph__item-track-line"
-                    className="stroke-theme-secondary-300"
+                    className="stroke-theme-secondary-300 dark:stroke-theme-dark-700"
                     strokeWidth={2}
                     pointerEvents="none"
                 />
@@ -63,7 +63,7 @@ export const DonutGraph = ({ data, size, renderTooltip, children }: DonutGraphPr
                 width={size}
                 height={size}
                 data-testid="DonutGraph__svg"
-                className="fill-theme-secondary-100"
+                className="fill-theme-secondary-100 dark:fill-theme-dark-950"
             >
                 <>
                     <circle {...backgroundCircle} />

--- a/resources/js/Components/PortfolioBreakdown/DonutChart.tsx
+++ b/resources/js/Components/PortfolioBreakdown/DonutChart.tsx
@@ -103,13 +103,15 @@ export const DonutChart = ({ assets, currency, size = 276 }: DonutChartPropertie
             >
                 <Icon
                     name="Wallet"
-                    className="bg-theme-primary-50 text-theme-primary-600"
+                    className="bg-theme-primary-50 text-theme-primary-600 dark:bg-theme-dark-950 dark:text-theme-primary-400"
                     size="lg"
                 />
 
-                <div className="mt-2 text-sm font-medium text-theme-secondary-700">{t("common.my_balance")}</div>
+                <div className="mt-2 text-sm font-medium text-theme-secondary-700 dark:text-theme-dark-200">
+                    {t("common.my_balance")}
+                </div>
 
-                <div className="text-lg font-medium">
+                <div className="text-lg font-medium dark:text-theme-dark-50">
                     <FormatFiat
                         value={totalValue.toString()}
                         currency={currency}

--- a/resources/js/Components/PortfolioBreakdown/PortfolioBreakdownTable.tsx
+++ b/resources/js/Components/PortfolioBreakdown/PortfolioBreakdownTable.tsx
@@ -31,15 +31,15 @@ const PortfolioBreakdownTableItem = ({
             >
                 <div className={`h-8 w-1 ${color}`} />
                 <div className="flex flex-col">
-                    <span className="font-medium">
+                    <span className="font-medium dark:text-theme-dark-50">
                         {asset.symbol}{" "}
-                        <span className="text-theme-secondary-500 sm:hidden">
+                        <span className="text-theme-secondary-500 dark:text-theme-dark-200 sm:hidden">
                             &nbsp;
                             <FormatPercentage value={Number(asset.percentage)} />
                         </span>
                     </span>
                     <span
-                        className="max-w-[8rem] truncate text-sm font-medium text-theme-secondary-500"
+                        className="max-w-[8rem] truncate text-sm font-medium text-theme-secondary-500 dark:text-theme-dark-300"
                         data-testid="PortfolioBreakdownItemAsset"
                     >
                         {asset.name}
@@ -49,7 +49,7 @@ const PortfolioBreakdownTableItem = ({
 
             <TableCell innerClassName="py-2.5 justify-end">
                 <div className="flex flex-col items-end">
-                    <span className="font-medium">
+                    <span className="font-medium dark:text-theme-dark-50">
                         <FormatFiat
                             value={asset.fiat_balance}
                             currency={currency}
@@ -57,7 +57,7 @@ const PortfolioBreakdownTableItem = ({
                     </span>
 
                     {!isOtherGroup(asset) && (
-                        <span className="whitespace-nowrap text-sm font-medium text-theme-secondary-500">
+                        <span className="whitespace-nowrap text-sm font-medium text-theme-secondary-500 dark:text-theme-dark-300">
                             <FormatCrypto
                                 token={{
                                     name: asset.name,
@@ -76,7 +76,7 @@ const PortfolioBreakdownTableItem = ({
                 className="hidden sm:table-cell"
                 innerClassName="justify-end"
             >
-                <span className="font-medium text-theme-secondary-700">
+                <span className="font-medium text-theme-secondary-700 dark:text-theme-dark-200">
                     <FormatPercentage value={Number(asset.percentage)} />
                 </span>
             </TableCell>

--- a/resources/js/Components/PortfolioBreakdown/PortfolioBreakdownText.tsx
+++ b/resources/js/Components/PortfolioBreakdown/PortfolioBreakdownText.tsx
@@ -25,8 +25,8 @@ const PortfolioBreakdownTextItem = ({
         >
             <span className={cn("h-3 w-1", color)} />
 
-            <span className="text-theme-secondary-700">{asset.symbol}</span>
-            <span className="text-theme-secondary-500">
+            <span className="text-theme-secondary-700 dark:text-theme-dark-200">{asset.symbol}</span>
+            <span className="text-theme-secondary-500 dark:text-theme-dark-100">
                 <FormatPercentage value={Number(asset.percentage)} />
             </span>
         </span>

--- a/resources/js/Components/PriceChange/PriceChange.tsx
+++ b/resources/js/Components/PriceChange/PriceChange.tsx
@@ -11,9 +11,9 @@ export const PriceChange = ({ change }: PriceChangeProperties): JSX.Element => {
             <div
                 data-testid="PriceChange__wrapper"
                 className={cn("font-medium", {
-                    "text-theme-success-600": type === "positive",
+                    "text-theme-success-600 dark:text-theme-success-500": type === "positive",
                     "text-theme-danger-400": type === "negative",
-                    "text-theme-secondary-700": type === "neutral",
+                    "text-theme-secondary-700 dark:text-theme-secondary-500": type === "neutral",
                 })}
             >
                 {formatPriceChange(change)}

--- a/resources/js/Components/Table/Table.tsx
+++ b/resources/js/Components/Table/Table.tsx
@@ -68,7 +68,7 @@ export const Table = <RowDataType extends Record<never, unknown>>({
     return (
         <div
             className={cn({
-                "rounded-xl border border-theme-secondary-300": variant === "default",
+                "rounded-xl border border-theme-secondary-300 dark:border-theme-dark-700": variant === "default",
                 "border-none": variant === "borderless",
             })}
         >

--- a/resources/js/Components/Table/TableCell.tsx
+++ b/resources/js/Components/Table/TableCell.tsx
@@ -22,7 +22,7 @@ const variantClass = (variant: TableCellVariant): string | undefined => {
 
 export const TableCell = ({
     innerClassName = "py-2.5",
-    hoverClassName = "group-hover:bg-theme-secondary-50",
+    hoverClassName = "group-hover:bg-theme-secondary-50 dark:group-hover:bg-theme-dark-800",
     className,
     paddingClassName = "px-5",
     variant = "middle",

--- a/resources/js/Components/Table/TableHeader.tsx
+++ b/resources/js/Components/Table/TableHeader.tsx
@@ -98,7 +98,7 @@ export const TableHeader = <RowDataType extends Record<never, unknown>>({
         <thead>
             {headerGroups.map((headerGroup, index) => (
                 <tr
-                    className="border-b border-theme-secondary-300"
+                    className="border-b border-theme-secondary-300 dark:border-theme-dark-700"
                     {...headerGroup.getHeaderGroupProps()}
                     key={index}
                 >

--- a/resources/js/Components/Table/TableRow.tsx
+++ b/resources/js/Components/Table/TableRow.tsx
@@ -6,7 +6,7 @@ export const TableRow = forwardRef<HTMLTableRowElement, TableRowProperties>(
     (
         {
             className,
-            borderClass = "group border-b last:border-b-0 border-theme-secondary-300 border-dashed",
+            borderClass = "group border-b last:border-b-0 border-theme-secondary-300 border-dashed dark:border-theme-dark-700",
             onClick,
             ...properties
         }: TableRowProperties,

--- a/resources/js/Components/WalletTokens/WalletTokensTable.blocks.tsx
+++ b/resources/js/Components/WalletTokens/WalletTokensTable.blocks.tsx
@@ -27,13 +27,13 @@ export const Action = ({ asset, onClick }: Omit<Properties, "currency">): JSX.El
         <>
             <Button
                 data-testid="WalletTokensTable__action_details"
-                className="hidden overflow-hidden group-hover:bg-theme-secondary-200 md:inline"
+                className="hidden overflow-hidden group-hover:bg-theme-secondary-200 dark:bg-theme-dark-800 dark:group-hover:bg-theme-dark-700 md:inline"
                 onClick={() => {
                     onClick(asset);
                 }}
                 variant="secondary"
             >
-                <div className="transition-default -mx-5 -my-2 px-5 py-2 hover:bg-theme-secondary-300">
+                <div className="transition-default -mx-5 -my-2 px-5 py-2 hover:bg-theme-secondary-300 dark:hover:bg-theme-dark-700 ">
                     {t("common.details")}
                 </div>
             </Button>
@@ -93,13 +93,13 @@ export const Token = memo(
                 <div className="flex flex-col items-start space-y-0.5 whitespace-nowrap font-medium">
                     <span
                         data-testid="WalletTokensTable__token_symbol"
-                        className="text-sm leading-5.5 text-theme-secondary-900 group-hover/token:text-theme-primary-700 sm:text-base sm:leading-6"
+                        className="text-sm leading-5.5 text-theme-secondary-900 group-hover/token:text-theme-primary-700 dark:text-theme-dark-50 dark:group-hover:text-theme-primary-400 sm:text-base sm:leading-6"
                     >
                         {asset.symbol}
                     </span>
                     <span
                         data-testid="WalletTokensTable__token_name"
-                        className="text-xs leading-4.5 text-theme-secondary-500 sm:text-sm sm:leading-5.5"
+                        className="text-xs leading-4.5 text-theme-secondary-500 dark:text-theme-dark-300 sm:text-sm sm:leading-5.5"
                     >
                         {asset.name}
                     </span>
@@ -144,7 +144,7 @@ export const Balance = ({ asset, currency }: Omit<Properties, "onClick">): JSX.E
                         <div
                             ref={fiatReference}
                             data-testid="WalletTokensTable__balance_fiat"
-                            className="truncate text-right text-sm leading-5.5 text-theme-secondary-900 sm:text-base sm:leading-6"
+                            className="truncate text-right text-sm leading-5.5 text-theme-secondary-900 dark:text-theme-dark-50 sm:text-base sm:leading-6"
                         >
                             <FormatFiat
                                 value={asset.fiat_balance ?? "0"}
@@ -172,7 +172,7 @@ export const Balance = ({ asset, currency }: Omit<Properties, "onClick">): JSX.E
                         >
                             <div
                                 ref={reference}
-                                className="truncate text-xs leading-4.5 text-theme-secondary-500 sm:text-sm sm:leading-5.5"
+                                className="truncate text-xs leading-4.5 text-theme-secondary-500 dark:text-theme-dark-300 sm:text-sm sm:leading-5.5"
                             >
                                 <FormatCrypto
                                     token={token}
@@ -199,7 +199,7 @@ export const Price = ({ asset, currency }: Omit<Properties, "onClick">): JSX.Ele
     >
         <span
             data-testid="WalletTokensTable__price_fiat"
-            className="text-base leading-6 text-theme-secondary-700"
+            className="text-base leading-6 text-theme-secondary-700 dark:text-theme-dark-200"
         >
             <FormatFiat
                 value={asset.token_price?.toString() ?? "0"}
@@ -223,7 +223,7 @@ export const Price = ({ asset, currency }: Omit<Properties, "onClick">): JSX.Ele
 export const MarketCap = ({ asset, currency }: Omit<Properties, "onClick">): JSX.Element => (
     <span
         data-testid="WalletTokensTable__market-cap"
-        className="font-medium text-theme-secondary-700"
+        className="font-medium text-theme-secondary-700 dark:text-theme-dark-200"
     >
         <FormatFiatShort
             value={asset.total_market_cap?.toString() ?? "0"}
@@ -235,7 +235,7 @@ export const MarketCap = ({ asset, currency }: Omit<Properties, "onClick">): JSX
 export const Volume = ({ asset, currency }: Omit<Properties, "onClick">): JSX.Element => (
     <span
         data-testid="WalletTokensTable__volume"
-        className="font-medium text-theme-secondary-700"
+        className="font-medium text-theme-secondary-700 dark:text-theme-dark-200"
     >
         <FormatFiatShort
             value={asset.total_volume?.toString() ?? "0"}

--- a/resources/js/Components/WalletTokens/WalletTokensTable.tsx
+++ b/resources/js/Components/WalletTokens/WalletTokensTable.tsx
@@ -118,7 +118,7 @@ const WalletTokensTableItem = ({
     return (
         <button
             type="button"
-            className="flex items-center justify-between rounded-xl border border-theme-secondary-300 px-4 py-5 outline-none outline-3 outline-offset-0 transition-all hover:outline-theme-primary-300 focus-visible:outline-theme-primary-300"
+            className="flex items-center justify-between rounded-xl border border-theme-secondary-300 px-4 py-5 outline-none outline-3 outline-offset-0 transition-all hover:outline-theme-primary-300 focus-visible:outline-theme-primary-300 dark:border-theme-dark-700"
             onClick={() => {
                 onDetailsClick(asset);
             }}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[general] Dark Mode](https://app.clickup.com/t/862kf8har): [[wallet] table dark mode](https://app.clickup.com/t/862kf8ebw), [[wallet] portfolio breakdown dark mode](https://app.clickup.com/t/862kf8evq) & [[wallet] portfolio header dark mode](https://app.clickup.com/t/862kf8exe)

## Summary

- Dark mode has been enabled for the entire `My wallet` page and all its children components.
- `Portfolio breakdown` slider now fully supports dark mode.
- `Table` component styles have been updated to support dark mode.

## Steps to reproduce

1. Run the app in `local` or `testing_e2e` mode.
2. Go to `Settings` and turn on the `Dark mode` slider.
3. Click on your user dropdown in the navbar.
4. Then, click on `My wallet` button.
6. Navigate in the page and see the magic ✨ 


https://github.com/ArdentHQ/dashbrd/assets/55117912/1549a19d-ecb9-43a5-99d9-9ba13acbeb28



## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
