### PR TITLE
refactor: articles publish date

### DIFF
--- a/app/Models/Article.php
+++ b/app/Models/Article.php
@@ -29,7 +29,7 @@ class Article extends Model implements HasMedia, Viewable
 
     protected $casts = [
         'category' => ArticleCategoryEnum::class,
-        'published_at' => 'date',
+        'published_at' => 'datetime',
     ];
 
     public function resolveRouteBinding($value, $field = null)
@@ -121,11 +121,14 @@ class Article extends Model implements HasMedia, Viewable
 
     /**
      * @param  Builder<self>  $query
+     * @param  'asc'|'desc'  $direction
      * @return Builder<self>
      */
-    public function scopeSortByPublishedDate(Builder $query): Builder
+    public function scopeSortByPublishedDate(Builder $query, string $direction = "desc"): Builder
     {
-        return $query->orderBy('articles.published_at', 'desc');
+        $nullsPosition = Str::lower($direction) === 'asc' ? 'NULLS FIRST' : 'NULLS LAST';
+
+        return $query->orderByRaw("articles.published_at {$direction} {$nullsPosition}");
     }
 
     /**

--- a/database/migrations/2023_09_20_124432_create_articles_table.php
+++ b/database/migrations/2023_09_20_124432_create_articles_table.php
@@ -19,7 +19,7 @@ return new class extends Migration
             $table->string('title');
             $table->string('slug')->unique();
             $table->string('category');
-            $table->date('published_at')->nullable();
+            $table->timestamp('published_at')->nullable()->index();
             $table->text('meta_description')->nullable();
             $table->text('content');
             $table->unsignedInteger('views_count_7days')->default(0);

--- a/tests/App/Http/Controllers/ArticleControllerTest.php
+++ b/tests/App/Http/Controllers/ArticleControllerTest.php
@@ -146,12 +146,12 @@ it('should get featured collections for an article', function () {
 
 it('should keep highlighted articles regardless of the sorting', function () {
     $highlightedArticles = Article::factory(3)->create([
-        'published_at' => now()->addMinutes(10),
+        'published_at' => now()->subMinutes(10),
     ]);
 
     $article1 = Article::factory()->create([
         'title' => 'nice bunny',
-        'published_at' => now()->addMinute(),
+        'published_at' => now()->subMinutes(30),
     ]);
 
     collect($highlightedArticles->concat([$article1]))->map(fn ($article) => $article


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
https://app.clickup.com/t/86790vqu2

This PR:
- makes `published_at` column `timestamp` instead of `date` because highlighted articles are based on this value, if we publish 2+ articles in a day the order might not be correct because they all will have the same `published_at` value
- makes `sortBy` method consistent with other models
- adds index for the `published_at` as we use this column to sort/filter results
- fixes flaky test

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [x] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
