### PR TITLE
fix: exception when saving user

### DIFF
--- a/app/Filament/Resources/UserResource/Pages/EditUser.php
+++ b/app/Filament/Resources/UserResource/Pages/EditUser.php
@@ -10,7 +10,6 @@ use App\Filament\Resources\UserResource\Pages\Traits\HandleRole;
 use Filament\Actions\DeleteAction;
 use Filament\Resources\Pages\EditRecord;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Arr;
 
 class EditUser extends EditRecord
 {
@@ -35,7 +34,7 @@ class EditUser extends EditRecord
         unset($data['role']);
 
         /** @var mixed $permissions */
-        $permissions = Arr::get($data, 'permissions', []);
+        $permissions = $data['permissions'] ?? [];
         unset($data['permissions']);
 
         $this->handleRole($record, $role);


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/862kh364f

If no permissions have been selected, the `permissions` key in the payload will be `null`. We used `Arr::get()` which will return the value if it exists, and since it does exist (but it's `null`), the exception happens.

I used null coalesce operator, which will default to an empty array if value doesn't exist or is `null`.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
