### PR TITLE
fix: add carousel key to featured collections to prevent swiper ID collisions

### DIFF
--- a/resources/js/Components/FeaturedCollectionsBanner/FeaturedCollectionsBanner.blocks.tsx
+++ b/resources/js/Components/FeaturedCollectionsBanner/FeaturedCollectionsBanner.blocks.tsx
@@ -77,6 +77,7 @@ export const CollectionCarousel = ({
                 shouldShowHeader={false}
                 onUpdate={checkIfRequiresNavigation}
                 spaceBetween={16}
+                carouselKey="collections"
             >
                 {collections.map((collection, index) => (
                     <CarouselItem
@@ -136,7 +137,7 @@ export const CollectionCarousel = ({
                 })}
             >
                 <div className="hidden md:block">
-                    <CarouselPreviousButton />
+                    <CarouselPreviousButton carouselKey="collections" />
                 </div>
             </div>
 
@@ -156,10 +157,13 @@ export const CollectionCarousel = ({
                 })}
             >
                 <div className="block md:hidden">
-                    <CarouselPreviousButton />
+                    <CarouselPreviousButton carouselKey="collections" />
                 </div>
 
-                <CarouselNextButton className="flex-shrink-0" />
+                <CarouselNextButton
+                    carouselKey="collections"
+                    className="flex-shrink-0"
+                />
             </div>
         </div>
     );


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/862kh4ex8

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
