### PR TITLE
refactor: skeleton loader for article cards

### DIFF
--- a/resources/css/_skeletons.css
+++ b/resources/css/_skeletons.css
@@ -20,3 +20,29 @@
         rgb(var(--theme-color-dark-700))
     );
 }
+
+.dark .react-loading-skeleton.skeleton-primary {
+    background-color: rgb(var(--theme-color-primary-400));
+}
+
+.dark .react-loading-skeleton.skeleton-primary::after {
+    background-image: linear-gradient(
+        90deg,
+        rgb(var(--theme-color-primary-500)),
+        rgb(var(--theme-color-primary-600)),
+        rgb(var(--theme-color-primary-500))
+    );
+}
+
+.react-loading-skeleton.skeleton-primary {
+    background-color: rgb(var(--theme-color-dark-600));
+}
+
+.react-loading-skeleton.skeleton-primary::after {
+    background-image: linear-gradient(
+        90deg,
+        rgb(var(--theme-color-dark-700)),
+        rgb(var(--theme-color-dark-800)),
+        rgb(var(--theme-color-dark-700))
+    );
+}

--- a/resources/js/Components/Articles/Article.blocks.tsx
+++ b/resources/js/Components/Articles/Article.blocks.tsx
@@ -78,7 +78,7 @@ export const FeaturedCollections = ({
                             isCircle
                             className={cn("h-6 w-6 rounded-full ring-2", {
                                 "bg-white ring-white dark:bg-theme-dark-800 dark:ring-theme-dark-800": !isLargeVariant,
-                                "bg-theme-dark-900 ring-theme-dark-900 dark:bg-theme-primary-800 dark:ring-theme-primary-800":
+                                "skeleton-primary bg-theme-dark-900 ring-theme-dark-900 dark:bg-theme-primary-800 dark:ring-theme-primary-800":
                                     isLargeVariant,
                             })}
                             errorClassName="!p-0"

--- a/resources/js/Components/Articles/ArticleCard/ArticleCard.tsx
+++ b/resources/js/Components/Articles/ArticleCard/ArticleCard.tsx
@@ -36,9 +36,11 @@ export const ArticleCard = ({
         >
             <div className="mx-2 mt-2 aspect-video overflow-hidden rounded-lg bg-theme-secondary-300">
                 <Img
-                    className="h-full w-full rounded-lg object-cover"
+                    className={cn("h-full w-full rounded-lg object-cover", {
+                        "skeleton-primary": isLargeVariant,
+                    })}
                     wrapperClassName={cn("h-full [&>span]:h-full", {
-                        "bg-white dark:bg-theme-dark-900": !isLargeVariant,
+                        "bg-white dark:bg-theme-primary-900 ": !isLargeVariant,
                         "bg-theme-dark-900 group-hover:bg-theme-primary-700 dark:bg-theme-primary-700 dark:group-hover:bg-theme-primary-600":
                             isLargeVariant,
                     })}

--- a/resources/js/Pages/Articles/Index.tsx
+++ b/resources/js/Pages/Articles/Index.tsx
@@ -46,7 +46,7 @@ const ArticlesIndex = ({
                     className="pb-2 text-center dark:text-theme-dark-50 sm:text-left"
                 >
                     {t("pages.articles.header_title")}{" "}
-                    <span className="text-theme-primary-600">
+                    <span className="text-theme-primary-600 dark:text-theme-primary-400">
                         {initialHighlightedArticles.length + initialArticles.paginated.meta.total}
                     </span>{" "}
                     {initialHighlightedArticles.length + initialArticles.paginated.meta.total === 1


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[articles] skeleton loading cards dark mode](https://app.clickup.com/t/865da7v2g)

## Summary

- Skeleton loader has been updated for the different variants for article cards, in both light and dark mode.
<img width="1509" alt="image" src="https://github.com/ArdentHQ/dashbrd/assets/55117912/19820140-68bc-43eb-8a03-57f347648161">

<img width="1503" alt="image" src="https://github.com/ArdentHQ/dashbrd/assets/55117912/50740ed1-0466-446c-946c-286c4d4955bd">

- As an extra, colors for the dark mode in the count in the header for the articles count has been fixed.
<img width="1506" alt="image" src="https://github.com/ArdentHQ/dashbrd/assets/55117912/29d2436b-2447-4c8b-bc56-864776f763f3">


## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
