### PR TITLE
fix: coverage for unknown network prop in marketplaces component

### DIFF
--- a/resources/js/Components/Marketplaces.test.tsx
+++ b/resources/js/Components/Marketplaces.test.tsx
@@ -126,4 +126,20 @@ describe("Marketplaces", () => {
 
         expect(screen.getByTestId(testId)).toHaveAttribute("href", url);
     });
+
+    it("should render null url for unknown chain", () => {
+        render(
+            <Marketplaces
+                address={polygonCollection.address}
+                nftId={polygonNft.tokenNumber}
+                chainId={0 as ExplorerChains}
+                type="collection"
+            />,
+        );
+
+        expect(screen.getByTestId("NftMarketplaces__Opensea")).toHaveAttribute("href", "#");
+        expect(screen.getByTestId("NftMarketplaces__Rarible")).toHaveAttribute("href", "#");
+        expect(screen.getByTestId("NftMarketplaces__Blur")).toHaveAttribute("href", "#");
+        expect(screen.getByTestId("NftMarketplaces__LooksRare")).toHaveAttribute("href", "#");
+    });
 });

--- a/resources/js/Components/Marketplaces.tsx
+++ b/resources/js/Components/Marketplaces.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import { ButtonLink } from "@/Components/Buttons/ButtonLink";
 import { ExplorerChains } from "@/Utils/Explorer";
+import { isTruthy } from "@/Utils/is-truthy";
 
 interface Properties {
     type: "nft" | "collection";
@@ -24,12 +25,19 @@ const getNetworkName = (chainId: App.Enums.Chains): string | null => {
 export const Marketplaces = ({ type, chainId, address, nftId }: Properties): JSX.Element => {
     const { t } = useTranslation();
 
-    const getMarketplaceUrl = (marketplace: string): string =>
-        t(`urls.marketplaces.${marketplace}.${type}`, {
-            nftId,
-            network: getNetworkName(chainId),
-            address,
-        }).toLowerCase();
+    const getMarketplaceUrl = (marketplace: string): string => {
+        const networkName = getNetworkName(chainId);
+
+        if (isTruthy(networkName)) {
+            return t(`urls.marketplaces.${marketplace}.${type}`, {
+                nftId,
+                network: networkName,
+                address,
+            }).toLowerCase();
+        }
+
+        return "#";
+    };
 
     return (
         <div


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[test] flaky marketplaces test](https://app.clickup.com/t/862khkuej)

## Summary

- Coverage for the default case in `getNetworkName` has been added.
- Now, the buttons will get `#` if the network is invalid. This will prevent the URLs from having missing props.
- A unit test has been added for these changes.

<img width="690" alt="image" src="https://github.com/ArdentHQ/dashbrd/assets/55117912/041b0c3d-fdde-4010-9f61-795ab7c4a8bf">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
