### PR TITLE
 fix: refresh collection button styles 

### DIFF
--- a/resources/js/Pages/Collections/Components/CollectionsHeading/RefreshButton.tsx
+++ b/resources/js/Pages/Collections/Components/CollectionsHeading/RefreshButton.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { IconButton } from "@/Components/Buttons";
 import { Tooltip } from "@/Components/Tooltip";
 import { useAuthorizedAction } from "@/Hooks/useAuthorizedAction";
+import { useBreakpoint } from "@/Hooks/useBreakpoint";
 import { useToasts } from "@/Hooks/useToasts";
 import { isTruthy } from "@/Utils/is-truthy";
 
@@ -12,6 +13,7 @@ export const RefreshButton = ({ wallet }: { wallet: App.Data.Wallet.WalletData |
 
     const { authenticatedAction } = useAuthorizedAction();
     const { showToast } = useToasts();
+    const { isMdAndAbove } = useBreakpoint();
 
     const refresh = (): void => {
         void authenticatedAction((): void => {
@@ -60,6 +62,8 @@ export const RefreshButton = ({ wallet }: { wallet: App.Data.Wallet.WalletData |
                     }
                     type="button"
                     onClick={refresh}
+                    iconSize={isMdAndAbove ? "sm" : "md"}
+                    className="border-none disabled:!bg-opacity-0 md:border-solid disabled:md:!bg-opacity-100"
                 />
             </span>
         </Tooltip>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[Collections] My Collection refresh button styling incorrect on mobile](https://app.clickup.com/t/862khkj3n)

## Summary

- Styles for `Refresh` button on the collections page have been fixed.
- This has been done using just tailwind class names and the `useBreakpoint` hook for the icon size.

- Mobile view:
<img width="339" alt="image" src="https://github.com/ArdentHQ/dashbrd/assets/55117912/06bf6dd5-b96c-42ff-8256-8f2b4345830e">

- Desktop view:
<img width="1510" alt="image" src="https://github.com/ArdentHQ/dashbrd/assets/55117912/f100d62a-2e48-472f-a492-dd9dec050b5a">

## Steps to reproduce

1. Run the app in `local` or `test_e2e` mode.
2. Go to `/collections` page and see the magic ✨ 

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
