### PR TITLE
fix: remove redundant  tooltip in activity refresh button

### DIFF
--- a/resources/js/Pages/Collections/Components/CollectionNavigation/CollectionNavigation.tsx
+++ b/resources/js/Pages/Collections/Components/CollectionNavigation/CollectionNavigation.tsx
@@ -122,7 +122,7 @@ export const CollectionNavigation = ({
             return t("pages.collections.activities.loading_activities_collection");
         }
 
-        return t("common.refresh");
+        return null;
     };
 
     return (
@@ -145,7 +145,10 @@ export const CollectionNavigation = ({
                     </div>
 
                     {selectedTab === "activity" && (
-                        <Tooltip content={updateDisabledReason()}>
+                        <Tooltip
+                            content={updateDisabledReason()}
+                            disabled={!isTruthy(updateDisabledReason())}
+                        >
                             <div className="py-1">
                                 <Button
                                     icon="Refresh"

--- a/resources/js/Pages/Collections/Components/CollectionNavigation/CollectionNavigation.tsx
+++ b/resources/js/Pages/Collections/Components/CollectionNavigation/CollectionNavigation.tsx
@@ -168,6 +168,7 @@ export const CollectionNavigation = ({
             {selectedTab === "activity" && (
                 <Tooltip
                     content={updateDisabledReason()}
+                    disabled={!isTruthy(updateDisabledReason())}
                     touch
                 >
                     <div className="mt-6">

--- a/resources/js/Pages/Collections/View.tsx
+++ b/resources/js/Pages/Collections/View.tsx
@@ -244,7 +244,7 @@ const CollectionsView = ({
             return <EmptyBlock>{t("pages.collections.activities.ignores_activities")}</EmptyBlock>;
         }
 
-        if (isTruthy(isLoadingActivity)) {
+        if (isTruthy(isLoadingActivity) && activities?.paginated.data.length === 0) {
             return <EmptyBlock>{t("pages.collections.activities.loading_activities_collection")}</EmptyBlock>;
         }
 


### PR DESCRIPTION
## Summary
No task but, see discussion in https://helloardent.slack.com/archives/C04P3DGJJ1W/p1698768310805259

* Preserves the activity table when clicking "refresh" instead of replacing it with "Loading" message block.
* Removes the redundant tooltip on collection activity refresh button (See attached preview)

![image (11)](https://github.com/ArdentHQ/dashbrd/assets/22020168/5201e057-75d3-45a9-97b3-b8319cc50199)
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->



<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
