### PR TITLE
refactor: use async call in authenticatedAction

### DIFF
--- a/resources/js/Pages/Collections/Components/CollectionsHeading/RefreshButton.tsx
+++ b/resources/js/Pages/Collections/Components/CollectionsHeading/RefreshButton.tsx
@@ -16,10 +16,10 @@ export const RefreshButton = ({ wallet }: { wallet: App.Data.Wallet.WalletData |
     const { isMdAndAbove } = useBreakpoint();
 
     const refresh = (): void => {
-        void authenticatedAction((): void => {
+        void authenticatedAction(async () => {
             setDisabled(true);
 
-            void window.axios.post(route("refresh-collections"));
+            await window.axios.post(route("refresh-collections"));
 
             showToast({
                 type: "pending",

--- a/resources/js/Pages/Collections/View.tsx
+++ b/resources/js/Pages/Collections/View.tsx
@@ -266,7 +266,7 @@ const CollectionsView = ({
     };
 
     const handleRefreshActivity = (): void => {
-        void authenticatedAction((): void => {
+        void authenticatedAction(async () => {
             setIsLoadingActivity(true);
             requestActivityUpdate(collection.address);
 
@@ -275,7 +275,7 @@ const CollectionsView = ({
                 isExpanded: true,
             });
 
-            void axios.post(
+            await axios.post(
                 route("collection.refresh-activity", {
                     collection: collection.slug,
                 }),


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary


[This pr](https://github.com/ArdentHQ/dashbrd/pull/314/files) added the `authenticatedAction` but in order to work (show the connect modal if session is lost) the axios call need to be async

To test login with your wallet, open the collections page, clear browser data, press refresh, you should see the connect modal.

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
