### PR TITLE
feat: handle gallery drafts toolbar actions

### DIFF
--- a/resources/js/Pages/Galleries/MyGalleries/Create.tsx
+++ b/resources/js/Pages/Galleries/MyGalleries/Create.tsx
@@ -62,7 +62,7 @@ const Create = ({
 
     const { draftId } = getQueryParameters();
 
-    const { setDraftCover, setDraftNfts, setDraftTitle, draft, isSaving } = useGalleryDrafts(
+    const { setDraftCover, setDraftNfts, setDraftTitle, draft, isSaving, deleteDraft } = useGalleryDrafts(
         isTruthy(draftId) ? Number(draftId) : undefined,
         isTruthy(gallery?.slug),
     );
@@ -76,6 +76,10 @@ const Create = ({
     const { selectedNfts, data, setData, errors, submit, updateSelectedNfts, processing } = useGalleryForm({
         gallery,
         setDraftNfts,
+        onDelete: (): void => {
+            void deleteDraft();
+            replaceUrlQuery({ draftId: "" });
+        },
     });
 
     const totalValue = 0;

--- a/resources/js/Pages/Galleries/MyGalleries/Create.tsx
+++ b/resources/js/Pages/Galleries/MyGalleries/Create.tsx
@@ -76,7 +76,7 @@ const Create = ({
     const { selectedNfts, data, setData, errors, submit, updateSelectedNfts, processing } = useGalleryForm({
         gallery,
         setDraftNfts,
-        onDelete: (): void => {
+        deleteDraft: (): void => {
             void deleteDraft();
             replaceUrlQuery({ draftId: "" });
         },

--- a/resources/js/Pages/Galleries/MyGalleries/Create.tsx
+++ b/resources/js/Pages/Galleries/MyGalleries/Create.tsx
@@ -208,7 +208,6 @@ const Create = ({
                     setShowDeleteModal(true);
                 }}
                 onCancel={() => {
-                    setDraftTitle(data.name);
                     router.visit(route("my-galleries"));
                 }}
                 onPublish={publishHandler}

--- a/resources/js/Pages/Galleries/hooks/useGalleryForm.ts
+++ b/resources/js/Pages/Galleries/hooks/useGalleryForm.ts
@@ -14,11 +14,11 @@ interface UseGalleryFormProperties extends Record<string, unknown> {
 export const useGalleryForm = ({
     gallery,
     setDraftNfts,
-    onDelete,
+    deleteDraft,
 }: {
     gallery?: App.Data.Gallery.GalleryData;
     setDraftNfts?: (nfts: App.Data.Gallery.GalleryNftData[]) => void;
-    onDelete?: () => void;
+    deleteDraft?: () => void;
 }): {
     selectedNfts: App.Data.Gallery.GalleryNftData[];
     gallery?: App.Data.Gallery.GalleryData;
@@ -86,7 +86,7 @@ export const useGalleryForm = ({
                 });
             },
             onSuccess: () => {
-                onDelete?.();
+                deleteDraft?.();
             },
         });
     };

--- a/resources/js/Pages/Galleries/hooks/useGalleryForm.ts
+++ b/resources/js/Pages/Galleries/hooks/useGalleryForm.ts
@@ -14,9 +14,11 @@ interface UseGalleryFormProperties extends Record<string, unknown> {
 export const useGalleryForm = ({
     gallery,
     setDraftNfts,
+    onDelete,
 }: {
     gallery?: App.Data.Gallery.GalleryData;
     setDraftNfts?: (nfts: App.Data.Gallery.GalleryNftData[]) => void;
+    onDelete?: () => void;
 }): {
     selectedNfts: App.Data.Gallery.GalleryNftData[];
     gallery?: App.Data.Gallery.GalleryData;
@@ -82,6 +84,9 @@ export const useGalleryForm = ({
                     message: Object.values(errors)[0],
                     type: "error",
                 });
+            },
+            onSuccess: () => {
+                onDelete?.();
             },
         });
     };


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Closes: https://app.clickup.com/t/862kh23eg

Depends on #326  



> “Publish” - publish the current gallery and remove any draft we had for it

It will delete the draft once backend returns success response

> “Cancel” - return to the “My galleries” screen and save the current state as a draft

Left it out as we discussed in Slack: it doesn't seem necessary as we persist stuff once it happens. Only problem could be when user click on `Cancel` button right after inputting the title, but it shouldn't be problem as `onBlur` triggers regardless 

“Delete” - show the [delete modal](https://hackmd.io/7U6LZFILRrOWDkcD-ugauQ#Delete-Modal) if we had saved any data to a draft. If no data was saved yet (e.g. page has no title and no NFTs) then the delete action behaves similar to cancel.

> Left this out too as we don't show the `delete` button in the edit mode and drafts are not for the edit more, so there is no need to handle it.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
