### PR TITLE
refactor: dark mode for more soon article skeleton card

### DIFF
--- a/resources/js/Components/Articles/ArticleCard/ArticleCardSkeleton.tsx
+++ b/resources/js/Components/Articles/ArticleCard/ArticleCardSkeleton.tsx
@@ -12,7 +12,7 @@ export const ArticleCardSkeleton = ({ isLoading = true }: { isLoading?: boolean 
         >
             <div
                 className={cn("mx-2 mt-2 aspect-video items-center justify-center overflow-hidden rounded-lg", {
-                    "flex bg-theme-secondary-100": !isLoading,
+                    "flex bg-theme-secondary-100 dark:bg-theme-dark-800 ": !isLoading,
                 })}
             >
                 {isLoading ? (
@@ -20,7 +20,7 @@ export const ArticleCardSkeleton = ({ isLoading = true }: { isLoading?: boolean 
                         <Skeleton className="h-full w-full bg-theme-secondary-100" />
                     </div>
                 ) : (
-                    <p className="font-medium text-theme-secondary-500">{t("pages.articles.placeholder_more_soon")}</p>
+                    <p className="font-medium text-theme-secondary-500 dark:text-theme-dark-200">{t("pages.articles.placeholder_more_soon")}</p>
                 )}
             </div>
 

--- a/resources/js/Components/Articles/ArticleCard/ArticleCardSkeleton.tsx
+++ b/resources/js/Components/Articles/ArticleCard/ArticleCardSkeleton.tsx
@@ -20,7 +20,9 @@ export const ArticleCardSkeleton = ({ isLoading = true }: { isLoading?: boolean 
                         <Skeleton className="h-full w-full bg-theme-secondary-100" />
                     </div>
                 ) : (
-                    <p className="font-medium text-theme-secondary-500 dark:text-theme-dark-200">{t("pages.articles.placeholder_more_soon")}</p>
+                    <p className="font-medium text-theme-secondary-500 dark:text-theme-dark-200">
+                        {t("pages.articles.placeholder_more_soon")}
+                    </p>
                 )}
             </div>
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[articles] add dark mode to coming soon placeholders](https://app.clickup.com/t/862khvhg7)

## Summary

- Dark mode has been added to "More soon" skeleton cards for articles.

## Steps to reproduce

1. Run the app in `local` or `testing_e2e` mode.
2. Remove all the entries in your `articles` table in your local DB.
3. Go to `/articles` page.
4. Turn on dark mode in the navbar and see the magic ✨ 

## Screenshot

<img width="1510" alt="image" src="https://github.com/ArdentHQ/dashbrd/assets/55117912/94df5a9d-0e8c-4152-b15c-2f78924c7294">


> Note: Wanted to activate animation for skeleton components, but it seems odd and it was configured to be off, too. Let me know if it is necessary to turn it on.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
