### PR TITLE
feat: delete expired drafts

### DIFF
--- a/resources/js/Pages/Galleries/MyGalleries/Index.tsx
+++ b/resources/js/Pages/Galleries/MyGalleries/Index.tsx
@@ -1,10 +1,11 @@
-import { type ReactNode } from "react";
+import { type ReactNode, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { CreateGalleryButton } from "./Components/CreateGalleryButton";
 import Layout from "./Layout";
 import { NftGalleryCard } from "@/Components/Galleries";
 import { Heading } from "@/Components/Heading";
 import { Pagination } from "@/Components/Pagination";
+import { useGalleryDrafts } from "@/Pages/Galleries/hooks/useGalleryDrafts";
 
 const Index = ({
     title,
@@ -21,6 +22,12 @@ const Index = ({
     const { t } = useTranslation();
 
     const userGalleries = galleries.paginated;
+
+    const { deleteExpiredDrafts } = useGalleryDrafts(undefined, true);
+
+    useEffect(() => {
+        void deleteExpiredDrafts();
+    }, []);
 
     return (
         <Layout

--- a/resources/js/Pages/Galleries/hooks/useGalleryDrafts.test.ts
+++ b/resources/js/Pages/Galleries/hooks/useGalleryDrafts.test.ts
@@ -17,6 +17,7 @@ const defaultGalleryDraft = {
     title: "",
     cover: null,
     coverTye: null,
+    updatedAt: 169901639000,
 };
 
 const indexedDBMocks = {

--- a/resources/js/Pages/Galleries/hooks/useGalleryDrafts.ts
+++ b/resources/js/Pages/Galleries/hooks/useGalleryDrafts.ts
@@ -139,11 +139,11 @@ export const useGalleryDrafts = (givenDraftId?: number, disabled?: boolean): Gal
     };
 
     const deleteExpiredDrafts = async (): Promise<void> => {
-        const thirtyDaysAgo = new Date().getTime() - DRAFT_TTL_DAYS * 86400 * 1000;
+        const thresholdDaysAgo = new Date().getTime() - DRAFT_TTL_DAYS * 86400 * 1000;
         const drafts: GalleryDraft[] = await database.getAll();
 
         for (const draft of drafts) {
-            if ((draft.updatedAt ?? 0) < thirtyDaysAgo) {
+            if ((draft.updatedAt ?? 0) < thresholdDaysAgo) {
                 void database.deleteRecord(Number(draft.id));
             }
         }

--- a/resources/js/Pages/Galleries/hooks/useGalleryDrafts.ts
+++ b/resources/js/Pages/Galleries/hooks/useGalleryDrafts.ts
@@ -80,8 +80,6 @@ export const useGalleryDrafts = (givenDraftId?: number, disabled?: boolean): Gal
 
         const updatedAt = new Date().getTime();
 
-        const draftToSave = { ...draft, updatedAt };
-
         if (draft.id === null) {
             const walletDrafts = await getWalletDrafts();
 
@@ -91,16 +89,15 @@ export const useGalleryDrafts = (givenDraftId?: number, disabled?: boolean): Gal
                 return;
             }
 
-            const draftToCreate: Partial<GalleryDraft> = { ...draftToSave };
+            const draftToCreate: Partial<GalleryDraft> = { ...draft, updatedAt };
             delete draftToCreate.id;
 
             const id = await database.add(draftToCreate);
-            setDraft({ ...draft, id });
+            setDraft({ ...draft, id, updatedAt });
         } else {
-            await database.update(draftToSave);
+            await database.update(draft);
+            setDraft({ ...draft, updatedAt });
         }
-
-        setDraft(draftToSave);
 
         setSave(false);
         setIsSaving(false);

--- a/resources/js/databaseConfig.ts
+++ b/resources/js/databaseConfig.ts
@@ -11,6 +11,7 @@ export const databaseConfig = {
                 { name: "cover", keypath: "cover", options: { unique: false } },
                 { name: "coverType", keypath: "coverType", options: { unique: false } },
                 { name: "nfts", keypath: "nfts", options: { unique: false } },
+                { name: "createdAt", keypath: "createdAt", options: { unique: false } },
             ],
         },
     ],

--- a/resources/js/databaseConfig.ts
+++ b/resources/js/databaseConfig.ts
@@ -11,7 +11,7 @@ export const databaseConfig = {
                 { name: "cover", keypath: "cover", options: { unique: false } },
                 { name: "coverType", keypath: "coverType", options: { unique: false } },
                 { name: "nfts", keypath: "nfts", options: { unique: false } },
-                { name: "createdAt", keypath: "createdAt", options: { unique: false } },
+                { name: "updatedAt", keypath: "updatedAt", options: { unique: false } },
             ],
         },
     ],


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Closes: https://app.clickup.com/t/862kh23f0

> To avoid stale drafts being kept indefinitely, we should store a timestamp of when they were last edited and discard them from localstorage once they are older than 30 days. This will keep drafts up to date with the changes happening to addresses and avoids needless drafts from piling up.

> A way to handle this is to check upon page navigation to the gallery what the age is of the stored drafts and delete any that are expired before showing the list of drafts

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [x] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
