### PR TITLE
fix: external link url disappears

### DIFF
--- a/resources/js/Contexts/ExternalLinkContext.tsx
+++ b/resources/js/Contexts/ExternalLinkContext.tsx
@@ -1,10 +1,10 @@
 import { createContext, useContext, useState } from "react";
 import { ExternalLinkConfirmModal } from "@/Components/ExternalLinkConfirmModal";
-import { isTruthy } from "@/Utils/is-truthy";
 
 interface ContextProperties {
     allowedExternalDomains: string[];
     setUrl?: (url: string) => void;
+    setOpen?: (open: boolean) => void;
 }
 
 interface ProviderProperties extends ContextProperties {
@@ -20,21 +20,23 @@ export const ExternalLinkContextProvider = ({
     allowedExternalDomains = [],
 }: ProviderProperties): JSX.Element => {
     const [url, setUrl] = useState<string | undefined>();
+    const [open, setOpen] = useState(false);
 
     return (
         <ExternalLinkContext.Provider
             value={{
                 allowedExternalDomains,
                 setUrl,
+                setOpen,
             }}
         >
             <div>
                 {children}
 
                 <ExternalLinkConfirmModal
-                    isOpen={isTruthy(url)}
+                    isOpen={open}
                     onClose={() => {
-                        setUrl(undefined);
+                        setOpen(false);
                     }}
                     href={url}
                     hasDisabledLinkWarning={localStorage.getItem("has_disabled_link_warning") === "true"}
@@ -58,6 +60,7 @@ export const useExternalLinkContext = (): {
         isDomainAllowed: (url: string): boolean => context.allowedExternalDomains.includes(new URL(url).hostname),
         hasDisabledLinkWarning: localStorage.getItem("has_disabled_link_warning") === "true",
         openConfirmationModal: (url: string) => {
+            context.setOpen?.(true);
             context.setUrl?.(url);
         },
     };


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/862kj4b5v

Previously the shown/hidden state depended on URL being set or not. Now it's managed by its own `open` state, so we can leave the URL in the state until the next external link modal is opened, at which point the URL is just replaced with the new one. This way we have URL be visible even during the modal closing transition.

https://github.com/ArdentHQ/dashbrd/assets/6536260/47863e84-57a8-4d1e-bd80-9c4a8fd85204


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
