### PR TITLE
fix: tooltip arrow background color

### DIFF
--- a/resources/js/Components/Tooltip/Tooltip.tsx
+++ b/resources/js/Components/Tooltip/Tooltip.tsx
@@ -35,7 +35,7 @@ export const Tooltip = ({
                 "break-words [&.tippy-box]:rounded-lg [&.tippy-box]:leading-5.5 [&_.tippy-content]:p-0", // to unset some of Tippy default styles...
                 className,
                 {
-                    "[&.tippy-box>.tippy-svg-arrow]:fill-theme-secondary-900 [&.tippy-box]:bg-theme-secondary-900 dark:[&.tippy-box>.tippy-svg-arrow]:fill-theme-primary-50 dark:[&.tippy-box]:bg-theme-primary-50":
+                    "[&.tippy-box>.tippy-svg-arrow]:fill-theme-secondary-900 dark:[&.tippy-box>.tippy-svg-arrow]:fill-theme-primary-50 [&.tippy-box]:bg-theme-secondary-900 dark:[&.tippy-box]:bg-theme-primary-50":
                         variant === "default",
                     "[&.tippy-box>.tippy-svg-arrow]:fill-theme-danger-400 [&.tippy-box]:bg-theme-danger-400 [&.tippy-box]:text-white":
                         variant === "danger",

--- a/resources/js/Components/Tooltip/Tooltip.tsx
+++ b/resources/js/Components/Tooltip/Tooltip.tsx
@@ -35,7 +35,7 @@ export const Tooltip = ({
                 "break-words [&.tippy-box]:rounded-lg [&.tippy-box]:leading-5.5 [&_.tippy-content]:p-0", // to unset some of Tippy default styles...
                 className,
                 {
-                    "[&.tippy-box>.tippy-svg-arrow]:fill-theme-primary-50 [&.tippy-box]:bg-theme-secondary-900 dark:[&.tippy-box]:bg-theme-primary-50":
+                    "[&.tippy-box>.tippy-svg-arrow]:fill-theme-secondary-900 [&.tippy-box]:bg-theme-secondary-900 dark:[&.tippy-box>.tippy-svg-arrow]:fill-theme-primary-50 dark:[&.tippy-box]:bg-theme-primary-50":
                         variant === "default",
                     "[&.tippy-box>.tippy-svg-arrow]:fill-theme-danger-400 [&.tippy-box]:bg-theme-danger-400 [&.tippy-box]:text-white":
                         variant === "danger",


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/862kj4y8m

Tooltip changes were introduced by https://github.com/ArdentHQ/dashbrd/pull/301, but I don't see any tasks that indicate tooltip changes.

#### Before

![Screenshot 2023-11-06 at 11 09 08](https://github.com/ArdentHQ/dashbrd/assets/6536260/5f48160f-a952-4bed-969f-043cb3105938)


#### After

![Screenshot 2023-11-06 at 11 09 30](https://github.com/ArdentHQ/dashbrd/assets/6536260/1f5ccd6a-8fb0-448c-a0e2-3dbdb46970ad)


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
