### PR TITLE
fix: correct nft bg colors on dark mode for md 

### DIFF
--- a/resources/js/Pages/Collections/Nfts/Components/TraitsCarousel/TraitsCarousel.tsx
+++ b/resources/js/Pages/Collections/Nfts/Components/TraitsCarousel/TraitsCarousel.tsx
@@ -126,7 +126,7 @@ export const TraitsCarousel = ({
                     >
                         <div
                             className={cn(
-                                "flex w-full justify-between py-4 font-medium md:flex-col md:space-y-2 md:rounded-lg md:bg-theme-secondary-50 md:px-4 md:py-3 lg:bg-white dark:md:bg-theme-dark-900",
+                                "flex w-full justify-between py-4 font-medium md:flex-col md:space-y-2 md:rounded-lg md:bg-theme-secondary-50 md:px-4 md:py-3 dark:md:bg-theme-dark-900 lg:bg-white",
                                 borderClassName(index),
                             )}
                         >


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->
Closes https://app.clickup.com/t/860ryy09r 

Preview (md) matching the mobile colors:
![2023-11-06-135549_914x207_scrot](https://github.com/ArdentHQ/dashbrd/assets/22020168/c136e8c2-7816-4549-8d11-b3147dc4d0d7)



## Summary

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
