### PR TITLE
fix: use white tooltip on dark mode on articles

### DIFF
--- a/resources/css/_tooltips.css
+++ b/resources/css/_tooltips.css
@@ -1,0 +1,11 @@
+.tippy-box[data-theme="dark"] {
+    @apply bg-theme-primary-50 text-theme-dark-800;
+}
+
+.tippy-box[data-theme="dark"] .tippy-arrow::before {
+    @apply text-theme-primary-50;
+}
+
+.tippy-box[data-theme="dark"] svg {
+    @apply text-theme-secondary-700;
+}

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -9,6 +9,7 @@
 @import "./_collection.css";
 @import "./_gallery.css";
 @import "./_article.css";
+@import "./_tooltips.css";
 
 @tailwind base;
 @tailwind components;

--- a/resources/js/Pages/Articles/Components/ArticleContent.tsx
+++ b/resources/js/Pages/Articles/Components/ArticleContent.tsx
@@ -5,6 +5,7 @@ import Markdown from "react-markdown";
 import rehypeExternalLinks from "rehype-external-links";
 import rehypeRaw from "rehype-raw";
 import tippy, { inlinePositioning } from "tippy.js";
+import { useDarkModeContext } from "@/Contexts/DarkModeContext";
 import { extractDomain } from "@/Utils/extract-domain";
 import { remarkFigurePlugin } from "@/Utils/Remark/remarkFigurePlugin";
 
@@ -20,6 +21,8 @@ const externalIcon = `<svg width="12" height="12" viewBox="0 0 12 12" fill="none
 
 export const ArticleContent = ({ article }: Properties): JSX.Element => {
     const { t } = useTranslation();
+    const { isDark } = useDarkModeContext();
+
     useEffect(() => {
         const links = document.querySelectorAll<HTMLAnchorElement>(".article-content a[target=_blank]");
 
@@ -39,6 +42,7 @@ export const ArticleContent = ({ article }: Properties): JSX.Element => {
                     <span class="text-sm font-medium">${domain}</span>
                     ${externalIcon}
                 </span>`,
+                theme: isDark ? "dark" : "light",
                 allowHTML: true,
                 inlinePositioning: true,
                 plugins: [inlinePositioning],
@@ -50,7 +54,7 @@ export const ArticleContent = ({ article }: Properties): JSX.Element => {
                 tippy(link).destroy();
             });
         };
-    }, []);
+    }, [isDark]);
 
     return (
         <div className="article-content">


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Closes https://app.clickup.com/t/86dqha718

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
