### PR TITLE
fix: text color for non-selected tab item dark mode

### DIFF
--- a/resources/js/Components/Tabs.tsx
+++ b/resources/js/Components/Tabs.tsx
@@ -54,7 +54,7 @@ const getTabClasses = ({
             {
                 "border-transparent bg-white text-theme-secondary-900 shadow-sm dark:bg-theme-dark-800 dark:text-theme-dark-50":
                     selected,
-                "active:bg-theme-secondary-200 hover:bg-theme-secondary-300 dark:hover:bg-theme-dark-900":
+                "active:bg-theme-secondary-200 hover:bg-theme-secondary-300 dark:hover:bg-theme-dark-900 dark:text-theme-dark-200":
                     !selected && !disabled,
                 "cursor-not-allowed focus:bg-transparent active:bg-transparent dark:text-theme-dark-400": disabled,
             },


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[dark mode] tab text incorrect colour](https://app.clickup.com/t/86dqhaejg)

## Summary

- Text color for non-selected tab item in dark mode has been fixed.

## Steps to reproduce 

1. Run the app in `local` or `testing_e2e`.
2. Make sure your testing wallet has at least 1 token to register.
3. Click on your wallet dropdown from the navbar.
4. Click on `My wallet` button.
5. Once you are on `/wallet` page, click on any token you have registered.
6. Check the slider menu item tabs and see the magic ✨ 

<img width="1501" alt="image" src="https://github.com/ArdentHQ/dashbrd/assets/55117912/c2174e03-1b09-4d41-9930-bd9cc4d54e20">

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
