### PR TITLE
fix: featured collection placeholder dark mode

### DIFF
--- a/resources/js/Components/FeaturedCollectionsBanner/FeaturedCollectionsBanner.blocks.tsx
+++ b/resources/js/Components/FeaturedCollectionsBanner/FeaturedCollectionsBanner.blocks.tsx
@@ -66,7 +66,7 @@ export const CollectionCarousel = ({
             return (
                 <div
                     data-testid="CollectionCarousel__entry__no_image"
-                    className="aspect-square h-15 w-15 rounded-full border border-theme-secondary-300 bg-white object-cover"
+                    className="aspect-square h-15 w-15 rounded-full border border-theme-secondary-300 bg-white object-cover dark:border dark:border-solid dark:border-theme-dark-700 dark:bg-theme-dark-900"
                 />
             );
         }

--- a/resources/js/Components/FeaturedCollectionsBanner/FeaturedCollectionsBanner.blocks.tsx
+++ b/resources/js/Components/FeaturedCollectionsBanner/FeaturedCollectionsBanner.blocks.tsx
@@ -66,7 +66,7 @@ export const CollectionCarousel = ({
             return (
                 <div
                     data-testid="CollectionCarousel__entry__no_image"
-                    className="aspect-square h-15 w-15 rounded-full border border-theme-secondary-300 bg-white object-cover dark:border dark:border-solid dark:border-theme-dark-700 dark:bg-theme-dark-900"
+                    className="aspect-square h-15 w-15 rounded-full border border-theme-secondary-300 bg-white object-cover dark:border-theme-dark-700 dark:bg-theme-dark-900"
                 />
             );
         }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[dark mode] featured collection placeholder circle incorrect styling](https://app.clickup.com/t/86dqhaeky)

## Summary

- Featured collection placeholder now fully supports dark mode.

## Steps to reproduce 

1. Run the app in `local` or `testing_e2e` mode.
2. Make sure you have at least 1 NFT in your testing wallet.
3. Click on the `Create gallery` button from the homepage.
4. Scroll down the creation page and see the magic ✨ 

<img width="1507" alt="image" src="https://github.com/ArdentHQ/dashbrd/assets/55117912/7fa05557-5d11-475e-8207-321eec981c96">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
