### PR TITLE
fix: break words in article card

### DIFF
--- a/resources/js/Components/Articles/ArticleCard/ArticleCard.tsx
+++ b/resources/js/Components/Articles/ArticleCard/ArticleCard.tsx
@@ -68,11 +68,14 @@ export const ArticleCard = ({
                 </div>
 
                 <h4
-                    className={cn("transition-default mt-1 line-clamp-2 max-h-[3.5rem] text-lg font-medium leading-7", {
-                        "text-theme-secondary-900 group-hover:text-theme-primary-700 dark:text-theme-dark-50 dark:group-hover:text-theme-primary-400":
-                            !isLargeVariant,
-                        "text-theme-secondary-300": isLargeVariant,
-                    })}
+                    className={cn(
+                        "transition-default mt-1 line-clamp-2 max-h-[3.5rem] break-words text-lg font-medium leading-7",
+                        {
+                            "text-theme-secondary-900 group-hover:text-theme-primary-700 dark:text-theme-dark-50 dark:group-hover:text-theme-primary-400":
+                                !isLargeVariant,
+                            "text-theme-secondary-300": isLargeVariant,
+                        },
+                    )}
                 >
                     {article.title}
                 </h4>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[articles] break words in article card](https://app.clickup.com/t/86dqhae4w)

## Summary

- We now use `break-words` tailwind class to implement `overflow-wrap: break-word` style in our article cards.
- Article titles now fill the 2 lines and also truncate if the title is too long.

## Steps to reproduce

1. Run the latest migrations using `composer db:dev`.
2. Go to your database and edit any article you want to test. Remove the spaces, just make it one long word and set more characters if you want.
3. Save the changes in your DB.
4. Run the app in `local` or `testing_e2e` mode.
5. Go to `/articles` page.
6. Look for the article you edited and see the magic ✨ 

## Screenshots

- Main card:
<img width="490" alt="image" src="https://github.com/ArdentHQ/dashbrd/assets/55117912/e8ccd147-6105-4044-bc28-606794d97aaf">

- Regular card:
<img width="373" alt="image" src="https://github.com/ArdentHQ/dashbrd/assets/55117912/83c14d1c-39a2-4862-9817-528faf918c04">


<img width="1507" alt="image" src="https://github.com/ArdentHQ/dashbrd/assets/55117912/1196c0d6-fd5b-4807-a0d7-0d8bcb47c005">


## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
