### PR TITLE
refactor: ignore activity for invalid collections when refreshing NFT metadata

### DIFF
--- a/app/Http/Controllers/RefreshedNftController.php
+++ b/app/Http/Controllers/RefreshedNftController.php
@@ -28,7 +28,9 @@ class RefreshedNftController extends Controller
         $nft->touch('metadata_requested_at');
         RefreshNftMetadata::dispatch()->onQueue(Queues::NFTS);
 
-        FetchCollectionActivity::dispatch($collection)->onQueue(Queues::NFTS);
+        if ($collection->indexesActivities()) {
+            FetchCollectionActivity::dispatch($collection)->onQueue(Queues::NFTS);
+        }
 
         return response()->json([
             'success' => true,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/86dqhafcg

Even though the `FetchCollectionActivity` job will in fact [check for supply](https://github.com/ArdentHQ/dashbrd/blob/develop/app/Jobs/FetchCollectionActivity.php#L58), there's no need even to dispatch the job if we don't support activity for the collection (no supply, hard cap or blacklisted).

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
