### PR TITLE
fix: remove placeholder when gallery drafts exist

### DIFF
--- a/resources/js/Pages/Galleries/MyGalleries/Index.tsx
+++ b/resources/js/Pages/Galleries/MyGalleries/Index.tsx
@@ -55,7 +55,7 @@ const Index = ({
                     <CreateGalleryButton nftCount={nftCount} />
                 </div>
 
-                {userGalleries.meta.total === 0 && (
+                {!showDrafts && userGalleries.meta.total === 0 && (
                     <div className="flex items-center justify-center rounded-xl border border-theme-secondary-300 p-4">
                         <span className="text-center font-medium text-theme-secondary-700">
                             {t("pages.galleries.my_galleries.no_galleries")}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[gallery] remove placeholder when galleries exist](https://app.clickup.com/t/86dqhae6p)

## Summary

- "No galleries" placeholder will not be shown anymore if we have no galleries but drafts.


## Steps to reproduce

1. Run the app in `local` or `testing_e2e` mode.
2. Make sure you have at least 1 NFT in your testing wallet.
4. Make sure you have not created any gallery. If so, remove them.
3. Click on `Create a gallery` from the homepage.
5. Click on another page and go to `/my-galleries` page.
6. Select `Drafts` item in the side menu and see the magic ✨ 

## Screenshot

<img width="1508" alt="image" src="https://github.com/ArdentHQ/dashbrd/assets/55117912/4f5900c2-39f1-41c5-8e1c-0f5a4b7a8d60">


## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->

