### PR TITLE
refactor: place tooltip of article's "copy" button on the left

### DIFF
--- a/resources/js/Components/Clipboard/Clipboard.tsx
+++ b/resources/js/Components/Clipboard/Clipboard.tsx
@@ -2,7 +2,7 @@ import cn from "classnames";
 import { type HTMLAttributes, useRef } from "react";
 import { useTranslation } from "react-i18next";
 
-import { Placement, type ReferenceElement } from "tippy.js";
+import { type Placement, type ReferenceElement } from "tippy.js";
 import { Icon } from "@/Components/Icon";
 import { Tooltip } from "@/Components/Tooltip";
 import { useBreakpoint } from "@/Hooks/useBreakpoint";

--- a/resources/js/Components/Clipboard/Clipboard.tsx
+++ b/resources/js/Components/Clipboard/Clipboard.tsx
@@ -2,7 +2,7 @@ import cn from "classnames";
 import { type HTMLAttributes, useRef } from "react";
 import { useTranslation } from "react-i18next";
 
-import { type ReferenceElement } from "tippy.js";
+import { Placement, type ReferenceElement } from "tippy.js";
 import { Icon } from "@/Components/Icon";
 import { Tooltip } from "@/Components/Tooltip";
 import { useBreakpoint } from "@/Hooks/useBreakpoint";
@@ -14,6 +14,7 @@ export interface ClipboardProperties extends HTMLAttributes<HTMLDivElement> {
     copiedIconClass?: string;
     copiedIcon?: React.ReactNode;
     zIndex?: number;
+    tooltipPlacement?: Placement;
 }
 
 export const Clipboard = ({
@@ -24,6 +25,7 @@ export const Clipboard = ({
     copiedIconClass,
     copiedIcon,
     zIndex,
+    tooltipPlacement,
 }: ClipboardProperties): JSX.Element => {
     const { t } = useTranslation();
     const reference = useRef<(ReferenceElement & HTMLDivElement) | null>(null);
@@ -44,6 +46,7 @@ export const Clipboard = ({
             trigger={!isLgAndAbove ? "click" : "mouseenter focus"}
             hideAfter={!isLgAndAbove ? 1000 : undefined}
             zIndex={zIndex}
+            placement={tooltipPlacement}
             touch
         >
             <div

--- a/resources/js/Pages/Articles/Components/ArticleCopy.tsx
+++ b/resources/js/Pages/Articles/Components/ArticleCopy.tsx
@@ -12,6 +12,7 @@ export const ArticleCopy = ({ article }: Properties): JSX.Element => {
         <Clipboard
             text={url}
             copiedIconClass="group button-icon"
+            tooltipPlacement="left"
         >
             <IconButton icon="Copy" />
         </Clipboard>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/86dqhagtm

<img width="274" alt="Screenshot 2023-11-08 at 16 01 29" src="https://github.com/ArdentHQ/dashbrd/assets/6536260/b7ae9853-0776-4a8a-a7c4-f92040d7bcf5">

It still defaults to "default" behavior (top) in other places:

<img width="170" alt="Screenshot 2023-11-08 at 16 00 57" src="https://github.com/ArdentHQ/dashbrd/assets/6536260/199315c6-fa98-479c-ad42-31e41f9e792c">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
