### PR TITLE
refactor: disable sidebar item if there are no drafts

### DIFF
--- a/resources/js/Pages/Galleries/MyGalleries/Components/MyGalleryListboxMenu.tsx
+++ b/resources/js/Pages/Galleries/MyGalleries/Components/MyGalleryListboxMenu.tsx
@@ -1,4 +1,5 @@
 import { router } from "@inertiajs/react";
+import cn from "classnames";
 import { useTranslation } from "react-i18next";
 import { CreateGalleryButton } from "./CreateGalleryButton";
 import { Listbox } from "@/Components/Form/Listbox";
@@ -13,7 +14,7 @@ export const MyGalleryListboxMenu = ({
 }: {
     nftCount: number;
     publishedCount: number;
-    draftsCount: number | undefined;
+    draftsCount?: number;
 }): JSX.Element => {
     const { t } = useTranslation();
 
@@ -76,13 +77,18 @@ export const MyGalleryListboxMenu = ({
 
                     <Listbox.Option
                         value={draftRoute}
+                        isDisabled={draftsCount === undefined || draftsCount === 0}
                         classNames={{
                             optionLabel: "flex w-full justify-between",
                             iconContainer: "flex flex-1 justify-between",
                         }}
                     >
                         <span>{t("common.drafts")}</span>
-                        <span className="text-theme-secondary-700">{draftsCount}</span>
+                        <span
+                            className={cn(draftsCount !== undefined && draftsCount > 0 && "text-theme-secondary-700")}
+                        >
+                            {draftsCount}
+                        </span>
                     </Listbox.Option>
                 </Listbox>
             </div>

--- a/resources/js/Pages/Galleries/MyGalleries/Components/MyGallerySidebar.tsx
+++ b/resources/js/Pages/Galleries/MyGalleries/Components/MyGallerySidebar.tsx
@@ -30,6 +30,7 @@ export const MyGallerySidebar = ({
                 icon="Document"
                 title={t("common.drafts")}
                 isSelected={route().current(routeName, { draft: true })}
+                isDisabled={draftsCount === undefined || draftsCount === 0}
                 href={route(routeName, { draft: true })}
                 rightText={
                     draftsCount?.toString() ?? (


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/86dqhagx1

Since we load drafts async and it might take a bit, this PR keeps it disabled during this "loading" phase.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
