### PR TITLE
feat: redirect to "Publish" tab if user has no drafts

### DIFF
--- a/resources/js/Contexts/DraftGalleriesContext.tsx
+++ b/resources/js/Contexts/DraftGalleriesContext.tsx
@@ -52,11 +52,7 @@ export const DraftGalleriesContextProvider = ({ children }: ProviderProperties):
         const isMyGalleryDraftPage = route().current("my-galleries", { draft: true });
 
         if (isTruthy(drafts) && drafts.length === 0 && isMyGalleryDraftPage) {
-            router.visit(
-                route("my-galleries", {
-                    draft: false,
-                }),
-            );
+            router.visit(route("my-galleries"));
         }
     }, [drafts]);
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[gallery] redirect the user to "Published" tab if it has no drafts](https://app.clickup.com/t/86dqhahma)

## Summary

- If a user has multiple drafts and all of them gets removed, then the app will redirect the user to `Published` tab.

## Steps to reproduce

1. Run the app in `local` or `testing_e2e` mode.
2. Make sure you have at least 1 NFT in your testing wallet.
3. Click on Create a gallery from the homepage.
4. Click on another page and go to `/my-galleries` page.
5. Select Drafts item in the side menu.
6. Right click and inspect the page.
7. Go to the `Storage` tab from your browser.
8. Click on `IndexDb` and remove all the items from `gallery_drafts` table.
9. Reload the page and see the magic ✨ 


https://github.com/ArdentHQ/dashbrd/assets/55117912/a4048f8c-a982-4a79-b9d4-72a4df20a826


## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
