### PR TITLE
fix: collection outline on dark mode on touch devices

### DIFF
--- a/resources/css/_tables.css
+++ b/resources/css/_tables.css
@@ -53,12 +53,12 @@
 
 .table-list thead tr th:first-child::before {
     content: "";
-    @apply pointer-events-none absolute left-0 top-0 z-10 -ml-3 block h-full w-3 rounded-l-xl bg-theme-secondary-50 dark:dark:bg-theme-dark-950;
+    @apply pointer-events-none absolute left-0 top-0 z-10 -ml-3 block h-full w-3 rounded-l-xl bg-theme-secondary-50 dark:bg-theme-dark-950;
 }
 
 .table-list thead tr th:last-child::after {
     content: "";
-    @apply pointer-events-none absolute right-0 top-0 z-10 -mr-3 block h-full w-3 rounded-r-xl bg-theme-secondary-50 dark:dark:bg-theme-dark-950;
+    @apply pointer-events-none absolute right-0 top-0 z-10 -mr-3 block h-full w-3 rounded-r-xl bg-theme-secondary-50 dark:bg-theme-dark-950;
 }
 
 .table-list tbody tr {
@@ -72,7 +72,7 @@
 
 .table-list tbody tr:hover::after {
     content: "";
-    @apply outline-theme-primary-100;
+    @apply outline-theme-primary-100 dark:outline-theme-dark-500;
 }
 
 .table-list tbody tr td:first-child::before {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/86dqhahtz

A bit hard to see, but you can manually trigger "hover" classes on touch in Chrome.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
