### PR TITLE
fix: create gallery NFT image border color in dark mode

### DIFF
--- a/resources/js/Components/Galleries/NftGalleryCard.blocks.tsx
+++ b/resources/js/Components/Galleries/NftGalleryCard.blocks.tsx
@@ -67,7 +67,8 @@ const NftImage = ({
                 data-testid={`NftImageGrid__selected--${nft.tokenNumber}`}
                 className={cn("transition-default pointer-events-none absolute inset-0 rounded-xl", {
                     "border-2 border-theme-primary-600 dark:border-theme-primary-400": isSelected,
-                    "border-theme-primary-100 group-hover:border-3": !isSelected,
+                    "border-theme-primary-100 group-hover:border-3 dark:group-hover:border-theme-primary-400":
+                        !isSelected,
                 })}
             >
                 <div


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Closes: https://app.clickup.com/t/86dqhg50t

![image](https://github.com/ArdentHQ/dashbrd/assets/132887516/596332ad-bd7c-44bb-a76e-1d4658e89362)


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
