### PR TITLE
refactor: remove references to featured collections

### DIFF
--- a/app/Data/Articles/ArticleData.php
+++ b/app/Data/Articles/ArticleData.php
@@ -19,7 +19,7 @@ use Spatie\TypeScriptTransformer\Attributes\TypeScript;
 class ArticleData extends Data
 {
     /**
-     * @param  DataCollection<int, FeaturedCollectionData>  $featuredCollections
+     * @param  DataCollection<int, FeaturedCollectionData>  $collections
      */
     public function __construct(
         public int $id,
@@ -39,7 +39,7 @@ class ArticleData extends Data
         #[LiteralTypeScriptType('{ thumb: string | null, thumb2x: string | null }')]
         public array $authorAvatar,
         #[DataCollectionOf(FeaturedCollectionData::class)]
-        public DataCollection $featuredCollections,
+        public DataCollection $collections,
 
         public ?string $metaDescription,
     ) {
@@ -71,7 +71,7 @@ class ArticleData extends Data
                 'thumb' => $user->hasMedia('avatar') ? $user->getFirstMediaUrl('avatar', 'thumb') : null,
                 'thumb2x' => $user->hasMedia('avatar') ? $user->getFirstMediaUrl('avatar', 'thumb2x') : null,
             ],
-            featuredCollections: FeaturedCollectionData::collection($article->collections),
+            collections: FeaturedCollectionData::collection($article->collections),
             metaDescription: $article->meta_description,
         );
     }

--- a/app/Data/Articles/FeaturedCollectionData.php
+++ b/app/Data/Articles/FeaturedCollectionData.php
@@ -26,7 +26,7 @@ class FeaturedCollectionData extends Data
         return new self(
             name: $collection->name,
             slug: $collection->slug,
-            image: $collection->image,
+            image: $collection->extra_attributes->get('image'),
         );
     }
 }

--- a/app/Http/Controllers/ArticleController.php
+++ b/app/Http/Controllers/ArticleController.php
@@ -26,8 +26,7 @@ class ArticleController extends Controller
             $highlightedArticles = Article::query()
                 ->isPublished()
                 ->sortByPublishedDate()
-                ->with('media', 'user.media')
-                ->withFeaturedCollections()
+                ->with('media', 'user.media', 'collections')
                 ->limit(3)
                 ->get();
         }
@@ -36,11 +35,10 @@ class ArticleController extends Controller
         $articles = Article::query()
             ->isPublished()
             ->search($request->get('search'))
-            ->with('media', 'user.media')
+            ->with('media', 'user.media', 'collections')
             ->when($request->get('sort') !== 'popularity', fn ($q) => $q->sortById())
             ->when($request->get('sort') === 'popularity', fn ($q) => $q->sortByPopularity())
             ->whereNotIn('articles.id', $highlightedArticles->pluck('id'))
-            ->withFeaturedCollections()
             ->paginate($pageLimit)
             ->withQueryString();
 
@@ -73,8 +71,7 @@ class ArticleController extends Controller
         $popularArticles = ArticleData::collection(
             Article::sortByPopularity()
                 ->isPublished()
-                ->with('media', 'user.media')
-                ->withFeaturedCollections()
+                ->with('media', 'user.media', 'collections')
                 ->where('id', '!=', $article->id)
                 ->limit(4)
                 ->get()

--- a/app/Http/Controllers/CollectionController.php
+++ b/app/Http/Controllers/CollectionController.php
@@ -270,7 +270,7 @@ class CollectionController extends Controller
             ->when($request->get('sort') !== 'popularity', fn ($q) => $q->sortById())
             ->when($request->get('sort') === 'popularity', fn ($q) => $q->sortByPopularity())
             ->orderByPivot('order_index', 'asc')
-            ->withFeaturedCollections()
+            ->with('collections')
             ->paginate($pageLimit);
 
         /** @var PaginatedDataCollection<int, ArticleData> $paginated */

--- a/app/Models/Article.php
+++ b/app/Models/Article.php
@@ -36,7 +36,7 @@ class Article extends Model implements HasMedia, Viewable
 
     public function resolveRouteBinding($value, $field = null)
     {
-        return Article::query()->withFeaturedCollections()->where('articles.slug', $value)->first();
+        return Article::query()->with('collections')->where('articles.slug', $value)->first();
     }
 
     public function registerMediaCollections(): void
@@ -136,21 +136,6 @@ class Article extends Model implements HasMedia, Viewable
         $nullsPosition = Str::lower($direction) === 'asc' ? 'NULLS FIRST' : 'NULLS LAST';
 
         return $query->orderByRaw("articles.published_at {$direction} {$nullsPosition}");
-    }
-
-    /**
-     * @param  Builder<self>  $query
-     * @return Builder<self>
-     */
-    public function scopeWithFeaturedCollections(Builder $query): Builder
-    {
-        return $query->with(['collections' => function ($query) {
-            $query->select([
-                'collections.name',
-                'collections.slug',
-                'collections.extra_attributes->image as image',
-            ]);
-        }]);
     }
 
     public function metaDescription(): string

--- a/resources/js/Components/Articles/ArticleCard/ArticleCard.tsx
+++ b/resources/js/Components/Articles/ArticleCard/ArticleCard.tsx
@@ -105,7 +105,7 @@ export const ArticleCard = ({
                 </span>
 
                 <FeaturedCollections
-                    collections={article.featuredCollections}
+                    collections={article.collections}
                     variant={variant}
                 />
             </div>

--- a/resources/js/Components/Articles/ArticleListItem/ArticleListItem.tsx
+++ b/resources/js/Components/Articles/ArticleListItem/ArticleListItem.tsx
@@ -44,7 +44,7 @@ export const ArticleListItem = ({ article }: { article: App.Data.Articles.Articl
                         <span className="mr-2 hidden shrink-0 text-sm font-medium text-theme-secondary-700 dark:text-theme-dark-200 sm:block">
                             {t("pages.articles.featured_collections")}:
                         </span>
-                        <FeaturedCollections collections={article.featuredCollections} />
+                        <FeaturedCollections collections={article.collections} />
                     </div>
                 </div>
             </div>

--- a/resources/js/Pages/Articles/Show.tsx
+++ b/resources/js/Pages/Articles/Show.tsx
@@ -63,9 +63,9 @@ const ArticlesShow = ({ article, popularArticles }: Properties): JSX.Element => 
 
         <div className="px-6 pt-6 sm:px-8 md:pt-3 2xl:px-0">
             <FeaturedCollectionsBanner
-                collections={article.featuredCollections}
-                subtitle={tp("pages.articles.consists_of_collections", article.featuredCollections.length, {
-                    count: article.featuredCollections.length,
+                collections={article.collections}
+                subtitle={tp("pages.articles.consists_of_collections", article.collections.length, {
+                    count: article.collections.length,
                 })}
             />
         </div>

--- a/resources/js/Tests/Factories/Articles/ArticleDataFactory.ts
+++ b/resources/js/Tests/Factories/Articles/ArticleDataFactory.ts
@@ -22,7 +22,7 @@ export default class ArticleDataFactory extends ModelFactory<App.Data.Articles.A
             category: "news",
             publishedAt: Number(faker.finance.amount(1, 1500, 2)),
             metaDescription: faker.lorem.paragraph(),
-            featuredCollections: new NFTCollectionFactory()
+            collections: new NFTCollectionFactory()
                 .withImage()
                 .createMany(3) as App.Data.Articles.FeaturedCollectionData[],
             authorName: faker.name.firstName(),

--- a/resources/types/generated.d.ts
+++ b/resources/types/generated.d.ts
@@ -100,7 +100,7 @@ declare namespace App.Data.Articles {
         userId: number;
         authorName: string;
         authorAvatar: { thumb: string | null; thumb2x: string | null };
-        featuredCollections: Array<App.Data.Articles.FeaturedCollectionData>;
+        collections: Array<App.Data.Articles.FeaturedCollectionData>;
         metaDescription: string | null;
     };
     export type ArticlesData = {

--- a/tests/App/Models/ArticleTest.php
+++ b/tests/App/Models/ArticleTest.php
@@ -134,24 +134,6 @@ it('determines that article is not published if published_at is null', function 
     expect($article->isNotPublished())->toBeTrue();
 });
 
-it('should get article\'s collections', function () {
-    $collections = Collection::factory(2)->create();
-
-    $articles = Article::factory(2)->create([
-        'published_at' => now()->format('Y-m-d'),
-    ]);
-
-    $collections->map(function ($collection) use ($articles) {
-        $collection->articles()->attach($articles, ['order_index' => 1]);
-    });
-
-    $result = $articles->first()->withFeaturedCollections()->first();
-
-    expect($result->collections->count())->toBe(2)
-        ->and($result->collections->pluck('name'))->toContain($collections[0]->name)
-        ->and($result->collections->pluck('name'))->toContain($collections[1]->name);
-});
-
 it('should update article view counts', function () {
     $articles = Article::factory(3)->create();
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Now that we'll have an actual concept of "featured" collections, I thought it might be beneficial for us to remove references to "old" featured collections, which are not "featured" at all - but rather just collections assigned to an article.

We had this `withFeaturedCollections` scope on the article model, and that will 100% cause issues in the future once we add featured collections, since this doesn't load just featured collections, but just eager loads all collections for an article.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
