### PR TITLE
fix: remove login requirement for collections overview page

### DIFF
--- a/app/Http/Controllers/CollectionController.php
+++ b/app/Http/Controllers/CollectionController.php
@@ -62,6 +62,7 @@ class CollectionController extends Controller
                                 ->simplePaginate(12);
 
         return Inertia::render('Collections/Index', [
+            'allowsGuests' => true,
             'activeSort' => $request->query('sort') === 'floor-price' ? 'floor-price' : 'top',
             'filters' => [
                 'chain' => $request->query('chain') ?? null,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[collections] remove login requirement](https://app.clickup.com/t/86dqmd21d)

## Summary

- Login requirement has been removed from collections overview page.

## Steps to reproduce

1. Run the app in `local` mode.
2. Make sure you have your wallet disconnected.
3. Go to `/collections` page and see the magic ✨ 

<img width="1509" alt="image" src="https://github.com/ArdentHQ/dashbrd/assets/55117912/eca490b7-710a-417b-bb5d-0c628f695e1c">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
