### PR TITLE
refactor: limit featured collections to 4 on admin panel

### DIFF
--- a/app/Filament/Resources/CollectionResource.php
+++ b/app/Filament/Resources/CollectionResource.php
@@ -90,7 +90,7 @@ class CollectionResource extends Resource
                         ->action(function (Collection $collection) {
                             if (!$collection->is_featured && Collection::where('is_featured', true)->count() >= 4) {
                                 Notification::make()
-                                ->title('There are already 4 collections marked as featured. Please remove one before selecting a new one')
+                                ->title('There are already 4 collections marked as featured. Please remove one before selecting a new one.')
                                 ->warning()
                                 ->send();
                             } else {

--- a/app/Filament/Resources/CollectionResource.php
+++ b/app/Filament/Resources/CollectionResource.php
@@ -10,6 +10,7 @@ use App\Filament\Resources\CollectionResource\Pages\ViewCollection;
 use App\Models\Collection;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Form;
+use Filament\Notifications\Notification;
 use Filament\Resources\Resource;
 use Filament\Tables\Actions\Action;
 use Filament\Tables\Actions\ActionGroup;
@@ -87,9 +88,16 @@ class CollectionResource extends Resource
                 ActionGroup::make([
                     Action::make('updateIsFeatured')
                         ->action(function (Collection $collection) {
-                            $collection->update([
-                                'is_featured' => ! $collection->is_featured,
-                            ]);
+                            if (!$collection->is_featured && Collection::where('is_featured', true)->count() >= 4) {
+                                Notification::make()
+                                ->title('There are already 4 collections marked as featured. Please remove one before selecting a new one')
+                                ->warning()
+                                ->send();
+                            } else {
+                                return $collection->update([
+                                    'is_featured' => ! $collection->is_featured,
+                                ]);
+                            }
                         })
                         ->label(fn (Collection $collection) => $collection->is_featured ? 'Unmark as featured' : 'Mark as featured')
                         ->icon('heroicon-s-star'),

--- a/app/Filament/Resources/CollectionResource.php
+++ b/app/Filament/Resources/CollectionResource.php
@@ -88,7 +88,7 @@ class CollectionResource extends Resource
                 ActionGroup::make([
                     Action::make('updateIsFeatured')
                         ->action(function (Collection $collection) {
-                            if (!$collection->is_featured && Collection::where('is_featured', true)->count() >= 4) {
+                            if (! $collection->is_featured && Collection::where('is_featured', true)->count() >= 4) {
                                 Notification::make()
                                 ->title('There are already 4 collections marked as featured. Please remove one before selecting a new one.')
                                 ->warning()


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->


# [[admin] limit featured collections to 4](https://app.clickup.com/t/86dqmd268)

## Summary

- Admin cannot mark more than 4 collections as `featured` on the admin panel.
- We will display a warning alert instead.

## Steps to reproduce

1. Run the app in `local` mode.
2. Go to `/admin` panel.
3. Log in as an admin or super-admin.
4. Click on collections item.
5. Mark 4 collections as featured.
6. Try to mark a 5th one and see the magic ✨ 


https://github.com/ArdentHQ/dashbrd/assets/55117912/a06eee7c-74da-48da-8f7f-9ec38a520166



## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
