### PR TITLE
fix: add padding for galleries and draft cards in my galleries page

### DIFF
--- a/resources/js/Pages/Galleries/MyGalleries/Index.tsx
+++ b/resources/js/Pages/Galleries/MyGalleries/Index.tsx
@@ -48,7 +48,7 @@ const Drafts = ({
     }
 
     return (
-        <div className="-m-1 grid grid-flow-row grid-cols-1 gap-2 sm:grid-cols-2 md-lg:grid-cols-3">
+        <div className="-m-1 grid grid-flow-row grid-cols-1 gap-2 px-6 sm:grid-cols-2 sm:px-0 md-lg:grid-cols-3">
             {drafts.map((draft, index) => (
                 <NftGalleryDraftCard
                     key={index}
@@ -118,7 +118,7 @@ const StoredGalleries = ({ galleries }: Pick<Properties, "galleries">): JSX.Elem
 
     return (
         <>
-            <div className="-m-1 grid grid-flow-row grid-cols-1 gap-2 sm:grid-cols-2 md-lg:grid-cols-3">
+            <div className="-m-1 grid grid-flow-row grid-cols-1 gap-2 px-6 sm:grid-cols-2 sm:px-0 md-lg:grid-cols-3">
                 {userGalleries.data.map((gallery, index) => (
                     <NftGalleryCard
                         key={index}

--- a/resources/js/Pages/Galleries/MyGalleries/Index.tsx
+++ b/resources/js/Pages/Galleries/MyGalleries/Index.tsx
@@ -44,7 +44,7 @@ const Drafts = ({
     }
 
     if (drafts.length === 0) {
-        return <EmptyBlock>{t("pages.galleries.my_galleries.no_draft_galleries")}</EmptyBlock>;
+        return <EmptyBlock className="mx-6 sm:mx-0">{t("pages.galleries.my_galleries.no_draft_galleries")}</EmptyBlock>;
     }
 
     return (
@@ -113,7 +113,7 @@ const StoredGalleries = ({ galleries }: Pick<Properties, "galleries">): JSX.Elem
     };
 
     if (userGalleries.meta.total === 0) {
-        return <EmptyBlock>{t("pages.galleries.my_galleries.no_galleries")}</EmptyBlock>;
+        return <EmptyBlock className="mx-6 sm:mx-0">{t("pages.galleries.my_galleries.no_galleries")}</EmptyBlock>;
     }
 
     return (


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[my galleries] content width borked on mobile](https://app.clickup.com/t/86dqmx5ev)

## Summary

- Paddings have been fixed for galleries and draft cards in mobile view. It now matches the design.

## Steps to reproduce

1. Run the app in `local` or `testing_e2e` mode.
2. Make sure your wallet is connected.
3. Create at least 1 gallery and 1 draft.
4. Go to `/my-galleries` page and see the magic ✨ 

<img width="316" alt="image" src="https://github.com/ArdentHQ/dashbrd/assets/55117912/13b0e3f6-ad71-4908-a362-8b6a98a6ff80">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
