### PR TITLE
fix: rewind featured collections carousel

### DIFF
--- a/resources/js/Pages/Collections/Components/FeaturedCollections/FeaturedCollectionsCarousel.tsx
+++ b/resources/js/Pages/Collections/Components/FeaturedCollections/FeaturedCollectionsCarousel.tsx
@@ -1,4 +1,6 @@
+import React, { useState } from "react";
 import type Swiper from "swiper";
+import { FeaturedCollectionsItem } from "./FeaturedCollectionsItem";
 import {
     Carousel,
     CarouselItem,
@@ -6,7 +8,6 @@ import {
     CarouselPagination,
     CarouselPreviousButton,
 } from "@/Components/Carousel";
-import { FeaturedCollectionsItem } from "./FeaturedCollectionsItem";
 
 export const FeaturedCollectionsCarousel = ({
     featuredCollections,

--- a/resources/js/Pages/Collections/Components/FeaturedCollections/FeaturedCollectionsCarousel.tsx
+++ b/resources/js/Pages/Collections/Components/FeaturedCollections/FeaturedCollectionsCarousel.tsx
@@ -36,6 +36,7 @@ export const FeaturedCollectionsCarousel = ({
                     className="overflow-hidden lg:mx-8 lg:rounded-xl lg:border lg:border-theme-secondary-300 dark:lg:border-theme-dark-700 2xl:mx-0"
                     onSwiper={setCarousel}
                     autoHeight
+                    rewind
                     autoplay={{
                         delay: autoplayDelay,
                         pauseOnMouseEnter: true,

--- a/resources/js/Pages/Collections/Components/FeaturedCollections/FeaturedCollectionsCarousel.tsx
+++ b/resources/js/Pages/Collections/Components/FeaturedCollections/FeaturedCollectionsCarousel.tsx
@@ -1,6 +1,4 @@
-import React, { useState } from "react";
 import type Swiper from "swiper";
-import { FeaturedCollectionsItem } from "./FeaturedCollectionsItem";
 import {
     Carousel,
     CarouselItem,
@@ -8,6 +6,7 @@ import {
     CarouselPagination,
     CarouselPreviousButton,
 } from "@/Components/Carousel";
+import { FeaturedCollectionsItem } from "./FeaturedCollectionsItem";
 
 export const FeaturedCollectionsCarousel = ({
     featuredCollections,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

Follow-up fix for https://github.com/ArdentHQ/dashbrd/pull/505#pullrequestreview-1750962041

Sets the `rewind` prop by default in featured collections carousel, to always display the arrows.

## Summary

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
