### PR TITLE
fix: display placeholder for articles tab

### DIFF
--- a/resources/js/Pages/Articles/Components/ArticlesView.tsx
+++ b/resources/js/Pages/Articles/Components/ArticlesView.tsx
@@ -27,7 +27,7 @@ export const articlesViewDefaults = {
 
 export const ArticlesView = ({
     articles,
-    highlightedArticles,
+    highlightedArticles = [],
     isLoading,
     articlesState,
     dispatch,
@@ -134,7 +134,7 @@ export const ArticlesView = ({
 
                 {!isLoading &&
                     articlesToShow.length === 0 &&
-                    (!isTruthy(highlightedArticles)  || highlightedArticles?.length === 0) &&
+                    highlightedArticles?.length === 0 &&
                     query === "" && (
                         <EmptyBlock className="w-full">
                             {mode === "articles"

--- a/resources/js/Pages/Articles/Components/ArticlesView.tsx
+++ b/resources/js/Pages/Articles/Components/ArticlesView.tsx
@@ -132,7 +132,7 @@ export const ArticlesView = ({
 
                 {isLoading && displayType === DisplayTypes.List && <ArticlesLoadingList />}
 
-                {!isLoading && articlesToShow.length === 0 && highlightedArticles?.length === 0 && query === "" && (
+                {!isLoading && articlesToShow.length === 0 && highlightedArticles.length === 0 && query === "" && (
                     <EmptyBlock className="w-full">
                         {mode === "articles"
                             ? t("pages.articles.no_articles")
@@ -140,7 +140,7 @@ export const ArticlesView = ({
                     </EmptyBlock>
                 )}
 
-                {!isLoading && articlesToShow.length === 0 && highlightedArticles?.length === 0 && query !== "" && (
+                {!isLoading && articlesToShow.length === 0 && highlightedArticles.length === 0 && query !== "" && (
                     <EmptyBlock className="w-full">
                         {t("pages.collections.articles.no_articles_with_filters")}
                     </EmptyBlock>

--- a/resources/js/Pages/Articles/Components/ArticlesView.tsx
+++ b/resources/js/Pages/Articles/Components/ArticlesView.tsx
@@ -118,7 +118,7 @@ export const ArticlesView = ({
             {showHighlighted && (
                 <HighlightedArticles
                     isLoading={isLoading}
-                    articles={highlightedArticles ?? []}
+                    articles={highlightedArticles}
                     withFullBorder={displayType === DisplayTypes.List}
                 />
             )}

--- a/resources/js/Pages/Articles/Components/ArticlesView.tsx
+++ b/resources/js/Pages/Articles/Components/ArticlesView.tsx
@@ -132,7 +132,7 @@ export const ArticlesView = ({
 
                 {isLoading && displayType === DisplayTypes.List && <ArticlesLoadingList />}
 
-                {!isLoading && articlesToShow.length === 0 && highlightedArticles?.length === 0 && query === "" && (
+                {!isLoading && articlesToShow.length === 0 && (!highlightedArticles || highlightedArticles?.length === 0) && query === "" && (
                     <EmptyBlock className="w-full">
                         {mode === "articles"
                             ? t("pages.articles.no_articles")

--- a/resources/js/Pages/Articles/Components/ArticlesView.tsx
+++ b/resources/js/Pages/Articles/Components/ArticlesView.tsx
@@ -134,7 +134,7 @@ export const ArticlesView = ({
 
                 {!isLoading &&
                     articlesToShow.length === 0 &&
-                    (!highlightedArticles || highlightedArticles?.length === 0) &&
+                    (!isTruthy(highlightedArticles)  || highlightedArticles?.length === 0) &&
                     query === "" && (
                         <EmptyBlock className="w-full">
                             {mode === "articles"

--- a/resources/js/Pages/Articles/Components/ArticlesView.tsx
+++ b/resources/js/Pages/Articles/Components/ArticlesView.tsx
@@ -132,7 +132,7 @@ export const ArticlesView = ({
 
                 {isLoading && displayType === DisplayTypes.List && <ArticlesLoadingList />}
 
-                {!isLoading && articlesToShow.length === 0 && (!highlightedArticles || highlightedArticles?.length === 0) && query === "" && (
+                {!isLoading && articlesToShow.length === 0 && (!isTruthy(highlightedArticles) || highlightedArticles?.length === 0) && query === "" && (
                     <EmptyBlock className="w-full">
                         {mode === "articles"
                             ? t("pages.articles.no_articles")


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[collections] collection articles tab has no placeholder when collection is linked to 0 articles](https://app.clickup.com/t/86dqn8b9j)

## Summary

- The correct placeholder is now displayed when we have 0 articles to display for a collection with the following message: `No articles have been linked to this collection as of now`.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Steps to reproduce

1. Run the app in `local` or `testing_e2e` mode.
2. Make sure your testing wallet has a collection with no articles attached.
3. This can simply be done by running `php artisan horizon` and loading new collections.
4. Go to `/collections` page.
5. Select any new collection with no articles.
6. Click on `Articles` tab and see the magic ✨ 

<img width="1507" alt="image" src="https://github.com/ArdentHQ/dashbrd/assets/55117912/4bad3072-8dbc-4ee6-a817-afab494b0142">


## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
