### PR TITLE
refactor: make FetchCollectionFloorPrice dispatch in sync

### DIFF
--- a/app/Console/Commands/FetchCollectionFloorPrice.php
+++ b/app/Console/Commands/FetchCollectionFloorPrice.php
@@ -38,7 +38,7 @@ class FetchCollectionFloorPrice extends Command
         $this->forEachCollection(
             callback: function ($collection, $index) {
                 $this->dispatchDelayed(
-                    callback: fn () => FetchCollectionFloorPriceJob::dispatch(
+                    callback: fn () => FetchCollectionFloorPriceJob::dispatchSync(
                         chainId: $collection->network->chain_id,
                         address: $collection->address,
                     ),


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Closes: https://app.clickup.com/t/86dqj94tz


The `FetchCollectionFloorPrice` job is being delayed with an async closure;  this closure is adding the original job to the queue again, but it's not necessarily dispatched immediately, to resolve that changed  `dispatch` to `dispatchSync`

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
