### PR TITLE
fix: adjust spacing for empty blocks in articles tab

### DIFF
--- a/resources/js/Pages/Articles/Components/ArticlesView.tsx
+++ b/resources/js/Pages/Articles/Components/ArticlesView.tsx
@@ -18,7 +18,7 @@ import { ArticleSortBy, ArticleSortDropdown } from "@/Pages/Collections/Componen
 import { getQueryParameters } from "@/Utils/get-query-parameters";
 import { isTruthy } from "@/Utils/is-truthy";
 import { scrollToTop } from "@/Utils/scroll-to-top";
-import cn from 'classnames';
+import cn from "classnames";
 
 export const articlesViewDefaults = {
     pageLimit: 24,
@@ -124,10 +124,12 @@ export const ArticlesView = ({
                 />
             )}
 
-            <div className={cn("flex flex-col items-center", {
-                "space-y-0": articlesToShow.length === 0,
-                "space-y-6": articlesToShow.length !== 0
-            })}>
+            <div
+                className={cn("flex flex-col items-center", {
+                    "space-y-0": articlesToShow.length === 0,
+                    "space-y-6": articlesToShow.length !== 0,
+                })}
+            >
                 {articlesLoaded && displayType === DisplayTypes.Grid && <ArticlesGrid articles={articlesToShow} />}
 
                 {articlesLoaded && displayType === DisplayTypes.List && <ArticlesList articles={articlesToShow} />}

--- a/resources/js/Pages/Articles/Components/ArticlesView.tsx
+++ b/resources/js/Pages/Articles/Components/ArticlesView.tsx
@@ -18,6 +18,7 @@ import { ArticleSortBy, ArticleSortDropdown } from "@/Pages/Collections/Componen
 import { getQueryParameters } from "@/Utils/get-query-parameters";
 import { isTruthy } from "@/Utils/is-truthy";
 import { scrollToTop } from "@/Utils/scroll-to-top";
+import cn from 'classnames';
 
 export const articlesViewDefaults = {
     pageLimit: 24,
@@ -123,7 +124,10 @@ export const ArticlesView = ({
                 />
             )}
 
-            <div className="flex flex-col items-center space-y-6">
+            <div className={cn("flex flex-col items-center", {
+                "space-y-0": articlesToShow.length === 0,
+                "space-y-6": articlesToShow.length !== 0
+            })}>
                 {articlesLoaded && displayType === DisplayTypes.Grid && <ArticlesGrid articles={articlesToShow} />}
 
                 {articlesLoaded && displayType === DisplayTypes.List && <ArticlesList articles={articlesToShow} />}

--- a/resources/js/Pages/Articles/Components/ArticlesView.tsx
+++ b/resources/js/Pages/Articles/Components/ArticlesView.tsx
@@ -1,3 +1,4 @@
+import cn from "classnames";
 import { type Dispatch, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { DisplayType, DisplayTypes } from "@/Components/DisplayType";
@@ -18,7 +19,6 @@ import { ArticleSortBy, ArticleSortDropdown } from "@/Pages/Collections/Componen
 import { getQueryParameters } from "@/Utils/get-query-parameters";
 import { isTruthy } from "@/Utils/is-truthy";
 import { scrollToTop } from "@/Utils/scroll-to-top";
-import cn from "classnames";
 
 export const articlesViewDefaults = {
     pageLimit: 24,
@@ -127,7 +127,7 @@ export const ArticlesView = ({
             <div
                 className={cn("flex flex-col items-center", {
                     "space-y-0": articlesToShow.length === 0,
-                    "space-y-6": articlesToShow.length !== 0,
+                    "space-y-6": articlesToShow.length > 0,
                 })}
             >
                 {articlesLoaded && displayType === DisplayTypes.Grid && <ArticlesGrid articles={articlesToShow} />}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[collections] collection articles tab has no placeholder when collection is linked to 0 articles](https://app.clickup.com/t/86dqn8b9j)

## Summary

- Spacing for empty blocks in the articles tab from collections page has been fixed.

## Screenshots:

- Collection with articles:
<img width="1507" alt="image" src="https://github.com/ArdentHQ/dashbrd/assets/55117912/7ecf05d9-ff6b-4c56-91a9-223d4bd788e1">


- Collection with no articles:
<img width="1495" alt="image" src="https://github.com/ArdentHQ/dashbrd/assets/55117912/28c06068-64cb-4b2f-8b65-f7cf868307e0">


<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
