### PR TITLE
fix: whitespace above featured collections

### DIFF
--- a/resources/js/Pages/Collections/Index.tsx
+++ b/resources/js/Pages/Collections/Index.tsx
@@ -67,9 +67,14 @@ const CollectionsIndex = ({
     };
 
     return (
-        <DefaultLayout toastMessage={props.toast}>
+        <DefaultLayout
+            wrapperClassName="-mt-6 sm:-mt-8 lg:mt-0"
+            toastMessage={props.toast}
+        >
             <Head title={title} />
+
             <FeaturedCollectionsCarousel featuredCollections={featuredCollections} />
+
             <div className="mx-6 mt-8 sm:mx-8 lg:mt-12 2xl:mx-0">
                 <div className="flex items-center justify-between">
                     <Heading level={1}>{t("pages.collections.popular_collections")}</Heading>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/86dqp1rwk

1024px:
![Screenshot 2023-11-30 at 13 38 26](https://github.com/ArdentHQ/dashbrd/assets/6536260/e9f24d2f-ad2d-4a5f-802c-66b8f980d261)

768px:
![Screenshot 2023-11-30 at 13 38 42](https://github.com/ArdentHQ/dashbrd/assets/6536260/7b99ec31-424e-4b0e-b503-8d7b55dddef6)

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
