### PR TITLE
fix: disable `tokenId` decoding for Alchemy endpoints

### DIFF
--- a/app/Http/Client/Alchemy/AlchemyPendingRequest.php
+++ b/app/Http/Client/Alchemy/AlchemyPendingRequest.php
@@ -250,7 +250,7 @@ class AlchemyPendingRequest extends PendingRequest
                 // With getNFTMetadataBatch, alchemy returns tokens numbers (`tokenId` field) as number instead of hex,
                 // thus the `convertTokenNumber flag to save it as is without attempting to convert from hex.
                 // See https://docs.alchemy.com/reference/sdk-getnftmetadatabatch#response-1
-                return $this->parseNft($nft, $network->id, convertTokenNumber: false);
+                return $this->parseNft($nft, $network->id);
             })
             ->values();
 
@@ -363,7 +363,7 @@ class AlchemyPendingRequest extends PendingRequest
     /**
      * @param  array<mixed>  $nft
      */
-    public function parseNft(array $nft, int $networkId, bool $convertTokenNumber = true): Web3NftData
+    public function parseNft(array $nft, int $networkId): Web3NftData
     {
         $extractedFloorPrice = $this->tryExtractFloorPrice($nft);
         $collectionName = $this->collectionName($nft);
@@ -400,7 +400,7 @@ class AlchemyPendingRequest extends PendingRequest
             $bannerImageUrl = null;
         }
 
-        $tokenNumber = $convertTokenNumber === true ? CryptoUtils::hexToBigIntStr($nft['tokenId']) : $nft['tokenId'];
+        $tokenNumber = $nft['tokenId'];
 
         $error = Arr::get($nft, 'raw.error');
         $nftInfo = null;

--- a/app/Http/Client/Alchemy/AlchemyPendingRequest.php
+++ b/app/Http/Client/Alchemy/AlchemyPendingRequest.php
@@ -247,9 +247,6 @@ class AlchemyPendingRequest extends PendingRequest
         $nftItems = collect($response)
             ->filter(fn ($nft) => $this->filterNft($nft))
             ->map(function ($nft) use ($network) {
-                // With getNFTMetadataBatch, alchemy returns tokens numbers (`tokenId` field) as number instead of hex,
-                // thus the `convertTokenNumber flag to save it as is without attempting to convert from hex.
-                // See https://docs.alchemy.com/reference/sdk-getnftmetadatabatch#response-1
                 return $this->parseNft($nft, $network->id);
             })
             ->values();

--- a/tests/App/Jobs/FetchWalletNftsTest.php
+++ b/tests/App/Jobs/FetchWalletNftsTest.php
@@ -759,7 +759,7 @@ it('should not store base64 encoded asset images', function () {
         '*' => Http::response([
             'ownedNfts' => [
                 [
-                    'tokenId' => '0x0000000000000000000000000000000000000000000000000000000000000c92',
+                    'tokenId' => '3218',
                     'name' => 'tiny dinos #3218',
                     'contract' => [
                         'address' => '0xd9b78a2f1dafc8bb9c60961790d2beefebee56f4',
@@ -808,7 +808,7 @@ it('should use media thumbnail for collection image if no opensea image url', fu
         '*' => Http::response([
             'ownedNfts' => [
                 [
-                    'tokenId' => '0x0000000000000000000000000000000000000000000000000000000000000c92',
+                    'tokenId' => '3218',
                     'contract' => [
                         'address' => '0xd9b78a2f1dafc8bb9c60961790d2beefebee56f4',
                         'tokenType' => 'ERC721',
@@ -856,7 +856,7 @@ it('should use media gateway for collection image if no opensea image url', func
         '*' => Http::response([
             'ownedNfts' => [
                 [
-                    'tokenId' => '0x000000000000000000000000000000000000000000000000000000000000092',
+                    'tokenId' => '3218',
                     'contract' => [
                         'address' => '0xd9b78a2f1dafc8bb9c60961790d2beefebee56f4',
                         'tokenType' => 'ERC721',
@@ -903,7 +903,7 @@ it('should not store original asset image if it is in base64 encoded format', fu
         '*' => Http::response([
             'ownedNfts' => [
                 [
-                    'tokenId' => '0x0000000000000000000000000000000000000000000000000000000000000c92',
+                    'tokenId' => '3218',
                     'contract' => [
                         'tokenType' => 'ERC721',
                         'address' => '0xd9b78a2f1dafc8bb9c60961790d2beefebee56f4',
@@ -942,7 +942,7 @@ it('should extract social details from opensea', function () {
         '*' => Http::response([
             'ownedNfts' => [
                 [
-                    'tokenId' => '0x0000000000000000000000000000000000000000000000000000000000000c92',
+                    'tokenId' => '3218',
                     'contract' => [
                         'address' => '0xd9b78a2f1dafc8bb9c60961790d2beefebee56f4',
                         'tokenType' => 'ERC721',
@@ -989,7 +989,7 @@ it('should use opensea description for collection', function () {
         '*' => Http::response([
             'ownedNfts' => [
                 [
-                    'tokenId' => '0x0000000000000000000000000000000000000000000000000000000000000c92',
+                    'tokenId' => '3218',
                     'contract' => [
                         'tokenType' => 'ERC721',
                         'address' => '0xd9b78a2f1dafc8bb9c60961790d2beefebee56f4',
@@ -1027,7 +1027,7 @@ it('should handle nft traits', function () {
         '*' => Http::response([
             'ownedNfts' => [
                 [
-                    'tokenId' => '0x0000000000000000000000000000000000000000000000000000000000000c92',
+                    'tokenId' => '3218',
                     'contract' => [
                         'tokenType' => 'ERC721',
                         'address' => '0xd9b78a2f1dafc8bb9c60961790d2beefebee56f4',


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Closes: https://app.clickup.com/t/86dqpedrv

This PR removes `tokenId` decoding functionality, it is no longer needed as Alchemy V3 API handles it automatically.

https://docs.alchemy.com/reference/nft-api-v2-to-v3-migration-guide#overview-of-changes-in-nft-api-v3

> Decimal String token IDs: All token IDs are now served as decimal strings. In V2, token IDs were sometimes served as hexadecimal or decimal strings, which could lead to confusion and potential errors.



<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
