### PR TITLE
fix: add `typeNumeric` macro to migration

### DIFF
--- a/database/migrations/2023_12_11_202944_create_floor_price_history_table.php
+++ b/database/migrations/2023_12_11_202944_create_floor_price_history_table.php
@@ -4,14 +4,20 @@ declare(strict_types=1);
 
 use App\Models\Collection;
 use App\Models\Token;
+use Illuminate\Database\Grammar;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Fluent;
 
 return new class extends Migration
 {
     public function up(): void
     {
+        Grammar::macro('typeNumeric', function (Fluent $column) {
+            return $column->get('numeric_type');
+        });
+
         Schema::create('floor_price_history', function (Blueprint $table) {
             $table->id();
             $table->foreignIdFor(Collection::class)->constrained()->cascadeOnDelete()->index();


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Fixes the error when running `php artisan migrate`

```
INFO  Running migrations.  

  2023_12_11_202944_create_floor_price_history_table ................ 3ms FAIL

   BadMethodCallException 

  Method Tpetry\PostgresqlEnhanced\Schema\Grammars\Grammar::typeNumeric does not exist.
```

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
