### PR TITLE
fix: use my collections URL for sorting

### DIFF
--- a/resources/js/Pages/Collections/MyCollections/Index.tsx
+++ b/resources/js/Pages/Collections/MyCollections/Index.tsx
@@ -24,7 +24,7 @@ const sort = ({
     selectedChainIds?: number[];
 }): void => {
     router.get(
-        route("collections"),
+        route("my.collections"),
         {
             ...getQueryParameters(),
             sort: sortBy,

--- a/resources/js/Pages/Collections/MyCollections/Index.tsx
+++ b/resources/js/Pages/Collections/MyCollections/Index.tsx
@@ -24,7 +24,7 @@ const sort = ({
     selectedChainIds?: number[];
 }): void => {
     router.get(
-        route("my.collections"),
+        route("my-collections"),
         {
             ...getQueryParameters(),
             sort: sortBy,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Fixes sorting URL for my collections page.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
