### PR TITLE
fix: show the total supply for the number of NFTs in a featured collection

### DIFF
--- a/app/Data/Collections/CollectionFeaturedData.php
+++ b/app/Data/Collections/CollectionFeaturedData.php
@@ -38,7 +38,7 @@ class CollectionFeaturedData extends Data
         public ?string $banner,
         public ?string $openSeaSlug,
         public string $website,
-        public int $nftsCount,
+        public ?int $supply,
         #[DataCollectionOf(GalleryNftData::class)]
         public DataCollection $nfts,
         public bool $isFeatured,
@@ -63,7 +63,7 @@ class CollectionFeaturedData extends Data
             banner: $collection->extra_attributes->get('banner'),
             openSeaSlug: $collection->extra_attributes->get('opensea_slug'),
             website: $collection->website(),
-            nftsCount: $collection->nfts_count,
+            supply: $collection->supply,
             nfts: GalleryNftData::collection($collection->cachedNfts),
             isFeatured: $collection->is_featured,
             description: $collection->description,

--- a/app/Http/Controllers/CollectionController.php
+++ b/app/Http/Controllers/CollectionController.php
@@ -112,7 +112,6 @@ class CollectionController extends Controller
         $currency = $user ? $user->currency() : CurrencyCode::USD;
 
         $featuredCollections = Collection::featured()
-            ->withCount(['nfts'])
             ->get();
 
         $featuredCollections->each(function (Collection $collection) {

--- a/resources/js/Pages/Collections/Components/FeaturedCollections/FeaturedCollectionStats.tsx
+++ b/resources/js/Pages/Collections/Components/FeaturedCollections/FeaturedCollectionStats.tsx
@@ -13,7 +13,7 @@ export const FeaturedCollectionStats = ({
     floorPrice: string | null;
     floorPriceCurrency: string | null;
     floorPriceDecimals: number | null;
-    nftsCount: number;
+    nftsCount: number | null;
     volume: string | null;
 }): JSX.Element => {
     const { t } = useTranslation();

--- a/resources/js/Pages/Collections/Components/FeaturedCollections/FeaturedCollectionsItem.tsx
+++ b/resources/js/Pages/Collections/Components/FeaturedCollections/FeaturedCollectionsItem.tsx
@@ -55,7 +55,7 @@ const FeaturedCollectionInfo = ({ data }: { data: App.Data.Collections.Collectio
                             floorPrice={data.floorPrice}
                             floorPriceCurrency={data.floorPriceCurrency}
                             floorPriceDecimals={data.floorPriceDecimals}
-                            nftsCount={data.nftsCount}
+                            nftsCount={data.supply}
                             volume={data.volume}
                         />
 

--- a/resources/types/generated.d.ts
+++ b/resources/types/generated.d.ts
@@ -191,7 +191,7 @@ declare namespace App.Data.Collections {
         banner: string | null;
         openSeaSlug: string | null;
         website: string;
-        nftsCount: number;
+        supply: number | null;
         nfts: Array<App.Data.Gallery.GalleryNftData>;
         isFeatured: boolean;
         description: string | null;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/86dqv2ycx

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
