### PR TITLE
fix: increment featured collection description span in mobile

### DIFF
--- a/resources/js/Pages/Collections/Components/FeaturedCollections/FeaturedCollectionsItem.tsx
+++ b/resources/js/Pages/Collections/Components/FeaturedCollections/FeaturedCollectionsItem.tsx
@@ -46,7 +46,7 @@ const FeaturedCollectionInfo = ({ data }: { data: App.Data.Collections.Collectio
                         </div>
                     </div>
 
-                    <div className="my-3 line-clamp-4 h-24 text-base font-medium leading-6 text-theme-secondary-700 dark:text-theme-dark-200 xs:h-18 sm:h-12 md-lg:line-clamp-2">
+                    <div className="my-3 line-clamp-4 h-24 text-base font-medium leading-6 text-theme-secondary-700 dark:text-theme-dark-200 sm:h-12 md-lg:line-clamp-2">
                         {truncateDescription(data.description)}
                     </div>
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

# [[Featured Collections] Collection description should span over 4 lines on mobile](https://app.clickup.com/t/86dqvt7t0)

## Summary

<!-- What changes are being made? -->

- Fixed height for the featured collection's descriptions has been modified to respect the line span for mobile and desktop views. 

## Screenshots

- Mobile view (4 lines):
<img width="307" alt="image" src="https://github.com/ArdentHQ/dashbrd/assets/55117912/fb3d025b-ce35-45c7-bd23-4f81d2a07b89">

- Desktop view (2 lines):
<img width="1497" alt="image" src="https://github.com/ArdentHQ/dashbrd/assets/55117912/0aa633b9-cc08-4674-a9d0-9e2a92c4f991">


## Steps to reproduce

1. Run the app in `local` or `testing_e2e` mode.
2. Go to `/collections` page.
3. Focus on the featured collections slider and see the magic ✨ 

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
