### PR TITLE
fix: do not use Blade to render custom query if there are no parameters

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -19,6 +19,10 @@ if (! function_exists('get_query')) {
             throw new Exception(sprintf('Cannot read file: %s', $name));
         }
 
+        if (count($params) === 0) {
+            return $contents;
+        }
+
         // @codeCoverageIgnoreEnd
 
         return Blade::render($contents, $params);


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/86dqp2uyk

On the ClickUp card, I have concluded that those queries are always properly read from the filesystem, but the problem is when it comes to processing them with Blade. Blade does in fact compile them and writes the compiled version to a file in a temporary directory, but when it reads the compiled view back, it's empty.

The problem of Blade not reading the file is still a bit of a mystery. I still suspect it's something to do with CI setup with race condition between CI filesystem and booting the framework, as this never happens once the framework is fully loaded.

However, all migration files use a simple string without any custom parameters (variables) that might benefit from compiling with Blade. If there are no parameters, we can just avoid rendering with Blade and simply return back the original string. I have re-ran the CI job for 10 or so times, and the error didn't occur. If it still happens in the future, I'll be furious.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
