### PR TITLE
fix: flaky test in UI components

### DIFF
--- a/resources/js/Components/Collections/CollectionsFullTable/CollectionsFullTable.test.tsx
+++ b/resources/js/Components/Collections/CollectionsFullTable/CollectionsFullTable.test.tsx
@@ -266,4 +266,17 @@ describe("CollectionsFullTable", () => {
 
         expect(getByTestId("CollectionsTableItem__unknown-supply")).toBeInTheDocument();
     });
+
+    it("should show supply if it exists", () => {
+        const { queryByTestId } = render(
+            <CollectionsFullTable
+                collections={[{ ...collection, supply: 10 }]}
+                user={user}
+                activeSort={""}
+                setSortBy={vi.fn()}
+            />,
+        );
+
+        expect(queryByTestId("CollectionsTableItem__unknown-supply")).not.toBeInTheDocument();
+    });
 });


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/86dr4qwr4

We test that N/A is shown when supply is `null`, but we don't explicitly check that N/A is not shown if supply is not `null`. This edge case is sometimes triggered by model factory which sets `supply` as random value, including `null`.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
