### PR TITLE
fix: text color on the tab button should be `primary-900`

### DIFF
--- a/resources/js/Components/Tabs.test.tsx
+++ b/resources/js/Components/Tabs.test.tsx
@@ -82,7 +82,7 @@ describe("Tabs", () => {
             </Tabs.Button>,
         );
 
-        expect(screen.getByTestId("test").parentElement?.className).toContain("text-theme-secondary-900");
+        expect(screen.getByTestId("test").parentElement?.className).toContain("text-theme-primary-900");
     });
 
     it("marks button as disabled", () => {

--- a/resources/js/Components/Tabs.tsx
+++ b/resources/js/Components/Tabs.tsx
@@ -56,7 +56,7 @@ const getTabClasses = ({
             baseClassName,
             "justify-center select-none rounded-full px-4 h-8 text-sm -outline-offset-[3px]",
             {
-                "border-transparent bg-white text-theme-secondary-900 shadow-sm dark:bg-theme-dark-800 dark:text-theme-dark-50":
+                "border-transparent bg-white text-theme-primary-900 shadow-sm dark:bg-theme-dark-800 dark:text-theme-dark-50":
                     selected,
                 "active:bg-theme-secondary-200 hover:bg-theme-secondary-300 dark:hover:bg-theme-dark-900 dark:text-theme-dark-200":
                     !selected && !disabled,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/86dr5a3fu

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
