### PR TITLE
fix: "featured collections" overflows onto the next line on 768px

### DIFF
--- a/resources/js/Components/Articles/Article.blocks.test.tsx
+++ b/resources/js/Components/Articles/Article.blocks.test.tsx
@@ -5,7 +5,7 @@ import { render, screen } from "@/Tests/testing-library";
 
 describe("ArticleCardBlocks", () => {
     it("should calculate featured collection counts", () => {
-        expect(calculateCircleCount(10, 140)).toBe(5);
+        expect(calculateCircleCount(10, 140)).toBe(4);
         expect(calculateCircleCount(5, 150)).toBe(5);
         expect(calculateCircleCount(2, 45)).toBe(2);
     });

--- a/resources/js/Components/Articles/Article.blocks.test.tsx
+++ b/resources/js/Components/Articles/Article.blocks.test.tsx
@@ -5,6 +5,7 @@ import { render, screen } from "@/Tests/testing-library";
 
 describe("ArticleCardBlocks", () => {
     it("should calculate featured collection counts", () => {
+        expect(calculateCircleCount(10, 200)).toBe(7);
         expect(calculateCircleCount(10, 140)).toBe(4);
         expect(calculateCircleCount(5, 150)).toBe(5);
         expect(calculateCircleCount(2, 45)).toBe(2);

--- a/resources/js/Components/Articles/Article.blocks.tsx
+++ b/resources/js/Components/Articles/Article.blocks.tsx
@@ -7,7 +7,7 @@ import { Img } from "@/Components/Image";
 import { Tooltip } from "@/Components/Tooltip";
 
 export const calculateCircleCount = (totalCount: number, availableWidth: number): number => {
-    const circleWidth = 20;
+    const circleWidth = 22;
     const overlapWidth = 4;
     const hiddenLabelWidth = 29;
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/86dr5vnfu

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
