### PR TITLE
refactor: add methods to convert crypto to current fiat price of a token

### DIFF
--- a/app/Models/Token.php
+++ b/app/Models/Token.php
@@ -292,6 +292,8 @@ class Token extends Model
             return null;
         }
 
+        // (amount * price) / 10^decimals
+
         return BigDecimal::of($value)
                         ->multipliedBy($price)
                         ->dividedBy(BigInteger::ten()->power($this->decimals), roundingMode: RoundingMode::DOWN);

--- a/app/Models/Token.php
+++ b/app/Models/Token.php
@@ -280,11 +280,8 @@ class Token extends Model
     /**
      * Calculate the current fiat price of a value of a token in a given currency.
      */
-    public function toCurrentFiat(?string $value, CurrencyCode $currency = CurrencyCode::USD): ?BigDecimal
+    public function toCurrentFiat(string $value, CurrencyCode $currency = CurrencyCode::USD): ?BigDecimal
     {
-        if ($value === null) {
-            return null;
-        }
 
         $price = $this->currentPrice($currency);
 

--- a/app/Models/Traits/BelongsToNetwork.php
+++ b/app/Models/Traits/BelongsToNetwork.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Models\Traits;
 
 use App\Models\Network;
+use App\Models\Token;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 trait BelongsToNetwork
@@ -15,5 +16,10 @@ trait BelongsToNetwork
     public function network(): BelongsTo
     {
         return $this->belongsTo(Network::class);
+    }
+
+    public function nativeToken(): Token
+    {
+        return $this->network->nativeToken;
     }
 }

--- a/tests/App/Models/CollectionTest.php
+++ b/tests/App/Models/CollectionTest.php
@@ -16,6 +16,7 @@ use App\Models\Network;
 use App\Models\Nft;
 use App\Models\NftActivity;
 use App\Models\SpamContract;
+use App\Models\Token;
 use App\Models\User;
 use App\Models\Wallet;
 use Carbon\Carbon;
@@ -1522,4 +1523,16 @@ it('should sort collections', function () {
         $collection2, // 1
         $collection5, // 0
     ]);
+});
+
+it('can get native token for a network', function () {
+    $token = Token::factory()->matic()->create([
+        'is_native_token' => true,
+    ]);
+
+    $network = Network::polygon();
+
+    $collection = Collection::factory()->for($network)->create();
+
+    expect($collection->nativeToken()->is($token))->toBeTrue();
 });

--- a/tests/App/Models/TokenTest.php
+++ b/tests/App/Models/TokenTest.php
@@ -318,3 +318,37 @@ it('prioritize tokens by online status', function () {
         $tokenWith0->id,
     ]);
 });
+
+it('can get current price of a token in a specific currency', function () {
+    $token = Token::factory()->create([
+        'extra_attributes' => [
+            'market_data' => [
+                'current_prices' => [
+                    'usd' => 10.51,
+                ],
+            ],
+        ],
+    ]);
+
+    expect($token->currentPrice(CurrencyCode::USD))->toBe(10.51);
+    expect($token->currentPrice(CurrencyCode::EUR))->toBeNull();
+});
+
+it('can convert value to a current price of a token in a specific currency', function () {
+    $token = Token::factory()->create([
+        'decimals' => 18,
+        'extra_attributes' => [
+            'market_data' => [
+                'current_prices' => [
+                    'usd' => 1701.51,
+                ],
+            ],
+        ],
+    ]);
+
+    // (6780914114355034300*1701.51)/1e18
+
+    expect($token->toCurrentFiat('6780914114355034300', CurrencyCode::USD)->toFloat())->toBe(11537.79);
+    expect($token->toCurrentFiat('6780914114355034300', CurrencyCode::EUR))->toBeNull();
+    expect($token->toCurrentFiat(null, CurrencyCode::EUR))->toBeNull();
+});

--- a/tests/App/Models/TokenTest.php
+++ b/tests/App/Models/TokenTest.php
@@ -350,5 +350,4 @@ it('can convert value to a current price of a token in a specific currency', fun
 
     expect($token->toCurrentFiat('6780914114355034300', CurrencyCode::USD)->toFloat())->toBe(11537.79);
     expect($token->toCurrentFiat('6780914114355034300', CurrencyCode::EUR))->toBeNull();
-    expect($token->toCurrentFiat(null, CurrencyCode::EUR))->toBeNull();
 });


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Will be needed for #611, but decided to do this in another PR to keep things light. This adds 2 methods to the Token model.

1. `currentPrice($currency)` -> gets the current fiat price for a token from its meta attributes
2. `toCurrentFiat($value, $currency)` -> gets the current fiat value from some crypto value. It uses BigNumber library as these values can be very large numbers.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
