### PR TITLE
fix: flaky collection vote test

### DIFF
--- a/tests/App/Models/CollectionVoteTest.php
+++ b/tests/App/Models/CollectionVoteTest.php
@@ -14,6 +14,8 @@ test('collection has many votes', function () {
 
     expect($collection->votes()->count())->toBe(0);
 
+    Carbon::setTestNow();
+
     $collection->addVote($wallet);
 
     expect($collection->votes()->count())->toBe(1);


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/86dr9z7ef

The problem was that `addVote` runs `updateOrCreate()`, but on top of the wallet ID it also checks uniqueness of `voted_at`. If `voted_at` is even one second after the previous one, it would create a new vote instead of update existing one. So this occasionally happened.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
