### PR TITLE
fix: strip markdown from a featured collection's description

### DIFF
--- a/app/Data/Collections/CollectionFeaturedData.php
+++ b/app/Data/Collections/CollectionFeaturedData.php
@@ -13,6 +13,7 @@ use Spatie\LaravelData\Attributes\DataCollectionOf;
 use Spatie\LaravelData\Attributes\WithTransformer;
 use Spatie\LaravelData\Data;
 use Spatie\LaravelData\DataCollection;
+use Spatie\LaravelMarkdown\MarkdownRenderer;
 use Spatie\TypeScriptTransformer\Attributes\LiteralTypeScriptType;
 use Spatie\TypeScriptTransformer\Attributes\TypeScript;
 
@@ -49,6 +50,10 @@ class CollectionFeaturedData extends Data
 
     public static function fromModel(Collection $collection, CurrencyCode $currency): self
     {
+        $description = $collection->description === null
+                    ? null
+                    : html_entity_decode(strip_tags(app(MarkdownRenderer::class)->toHtml($collection->description)));
+
         return new self(
             id: $collection->id,
             name: $collection->name,
@@ -66,7 +71,7 @@ class CollectionFeaturedData extends Data
             nfts: GalleryNftData::collection($collection->nfts),
             supply: $collection->supply,
             isFeatured: $collection->is_featured,
-            description: $collection->description,
+            description: $description,
             volume: $collection->volume,
         );
     }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/86drd4kbd

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
