### PR TITLE
refactor: avoid `isTruthy` call in places where it's not needed

### DIFF
--- a/resources/js/Components/Articles/ArticleCard/ArticleErrorImage.tsx
+++ b/resources/js/Components/Articles/ArticleCard/ArticleErrorImage.tsx
@@ -1,15 +1,14 @@
 import cn from "classnames";
 import { ImageLoadError, ImageLoadErrorDark, ImageLoadErrorPrimary } from "@/images";
-import { isTruthy } from "@/Utils/is-truthy";
 
 export const ArticleErrorImage = ({
     className,
-    isLargeVariant,
+    isLargeVariant = false,
 }: {
     className?: string;
     isLargeVariant?: boolean;
 }): JSX.Element => {
-    if (isTruthy(isLargeVariant)) {
+    if (isLargeVariant) {
         return (
             <div
                 data-testid="ArticleErrorImageLargeVariant"

--- a/resources/js/Components/Collections/CollectionDescription/CollectionDescription.tsx
+++ b/resources/js/Components/Collections/CollectionDescription/CollectionDescription.tsx
@@ -5,7 +5,6 @@ import { useTranslation } from "react-i18next";
 import { Dialog } from "@/Components/Dialog";
 import { Link, LinkButton } from "@/Components/Link";
 import { Tooltip } from "@/Components/Tooltip";
-import { isTruthy } from "@/Utils/is-truthy";
 
 export const CollectionDescription = ({
     name,
@@ -19,70 +18,68 @@ export const CollectionDescription = ({
     const { t } = useTranslation();
     const [showDescriptionModal, setShowDescriptionModal] = useState(false);
 
-    return (
-        <>
-            {!isTruthy(description) && (
-                <Tooltip content={t("common.na")}>
-                    <div>
-                        <LinkButton
-                            data-testid="CollectionHeaderTop__about"
-                            className={cn(
-                                "border-b border-dashed border-theme-secondary-500 text-theme-secondary-500",
-                                linkClassName,
-                            )}
-                            disabled
-                        >
-                            {name}
-                        </LinkButton>
-                    </div>
-                </Tooltip>
-            )}
-
-            {isTruthy(description) && (
-                <>
+    if (description === null || description.length === 0) {
+        return (
+            <Tooltip content={t("common.na")}>
+                <div>
                     <LinkButton
                         data-testid="CollectionHeaderTop__about"
                         className={cn(
-                            "transition-default border-b border-dashed border-theme-secondary-900 hover:border-transparent hover:text-theme-primary-700 dark:border-theme-dark-50 dark:text-theme-dark-50 dark:hover:border-theme-dark-200 dark:hover:text-theme-dark-200",
+                            "border-b border-dashed border-theme-secondary-500 text-theme-secondary-500",
                             linkClassName,
                         )}
-                        onClick={() => {
-                            setShowDescriptionModal(true);
-                        }}
+                        disabled
                     >
                         {name}
                     </LinkButton>
+                </div>
+            </Tooltip>
+        );
+    }
 
-                    <Dialog
-                        title={name}
-                        isOpen={showDescriptionModal}
-                        onClose={() => {
-                            setShowDescriptionModal(false);
+    return (
+        <>
+            <LinkButton
+                data-testid="CollectionHeaderTop__about"
+                className={cn(
+                    "transition-default border-b border-dashed border-theme-secondary-900 hover:border-transparent hover:text-theme-primary-700 dark:border-theme-dark-50 dark:text-theme-dark-50 dark:hover:border-theme-dark-200 dark:hover:text-theme-dark-200",
+                    linkClassName,
+                )}
+                onClick={() => {
+                    setShowDescriptionModal(true);
+                }}
+            >
+                {name}
+            </LinkButton>
+
+            <Dialog
+                title={name}
+                isOpen={showDescriptionModal}
+                onClose={() => {
+                    setShowDescriptionModal(false);
+                }}
+            >
+                <div
+                    data-testid="CollectionHeaderTop__description_modal"
+                    className={cn(
+                        "text-theme-secondary-700 [&_div]:space-y-6",
+                        "dark:text-theme-dark-200 [&_a]:text-theme-primary-600 hover:[&_a]:underline",
+                    )}
+                >
+                    <Markdown
+                        data-testid="CollectionHeaderTop__html"
+                        options={{
+                            disableParsingRawHTML: true,
+                            overrides: {
+                                img: MarkdownImage,
+                                a: MarkdownLink,
+                            },
                         }}
                     >
-                        <div
-                            data-testid="CollectionHeaderTop__description_modal"
-                            className={cn(
-                                "text-theme-secondary-700 [&_div]:space-y-6",
-                                "dark:text-theme-dark-200 [&_a]:text-theme-primary-600 hover:[&_a]:underline",
-                            )}
-                        >
-                            <Markdown
-                                data-testid="CollectionHeaderTop__html"
-                                options={{
-                                    disableParsingRawHTML: true,
-                                    overrides: {
-                                        img: MarkdownImage,
-                                        a: MarkdownLink,
-                                    },
-                                }}
-                            >
-                                {description}
-                            </Markdown>
-                        </div>
-                    </Dialog>
-                </>
-            )}
+                        {description}
+                    </Markdown>
+                </div>
+            </Dialog>
         </>
     );
 };

--- a/resources/js/Components/ErrorBlock/ErrorBlock.blocks.tsx
+++ b/resources/js/Components/ErrorBlock/ErrorBlock.blocks.tsx
@@ -5,7 +5,7 @@ import { Heading } from "@/Components/Heading";
 export const ErrorContent = ({
     title,
     description,
-    contactEmail,
+    contactEmail = "",
     showActionButtons = true,
 }: {
     title?: string;
@@ -25,7 +25,7 @@ export const ErrorContent = ({
 
             {showActionButtons && (
                 <div className="mt-6 flex flex-col space-y-3 sm:flex-row sm:justify-center sm:space-x-3 sm:space-y-0">
-                    {contactEmail !== undefined && (
+                    {contactEmail.length > 0 && (
                         <ButtonLink
                             className="w-full justify-center sm:w-auto"
                             variant="primary"

--- a/resources/js/Components/ErrorBlock/ErrorBlock.blocks.tsx
+++ b/resources/js/Components/ErrorBlock/ErrorBlock.blocks.tsx
@@ -1,7 +1,6 @@
 import { useTranslation } from "react-i18next";
 import { ButtonLink } from "@/Components/Buttons/ButtonLink";
 import { Heading } from "@/Components/Heading";
-import { isTruthy } from "@/Utils/is-truthy";
 
 export const ErrorContent = ({
     title,
@@ -26,7 +25,7 @@ export const ErrorContent = ({
 
             {showActionButtons && (
                 <div className="mt-6 flex flex-col space-y-3 sm:flex-row sm:justify-center sm:space-x-3 sm:space-y-0">
-                    {isTruthy(contactEmail) && (
+                    {contactEmail !== undefined && (
                         <ButtonLink
                             className="w-full justify-center sm:w-auto"
                             variant="primary"

--- a/resources/js/Components/Form/TextInput/TextInput.tsx
+++ b/resources/js/Components/Form/TextInput/TextInput.tsx
@@ -84,6 +84,7 @@ const TextInputRoot = forwardRef<HTMLInputElement, TextInputProperties>(
                         className,
                     )}
                     ref={input}
+                    disabled={disabled}
                     {...properties}
                 />
 

--- a/resources/js/Components/Form/TextInput/TextInput.tsx
+++ b/resources/js/Components/Form/TextInput/TextInput.tsx
@@ -5,7 +5,6 @@ import { TextInputAvatar, TextInputButton } from "./TextInput.blocks";
 import { type TextInputProperties } from "./TextInput.contracts";
 import { textInputDynamicClassnames } from "./TextInput.styles";
 import { useTextInput } from "./useTextInput";
-import { isTruthy } from "@/Utils/is-truthy";
 
 const TextInputRoot = forwardRef<HTMLInputElement, TextInputProperties>(
     (
@@ -19,6 +18,7 @@ const TextInputRoot = forwardRef<HTMLInputElement, TextInputProperties>(
             before,
             onFocus,
             onBlur,
+            disabled = false,
             ...properties
         },
         reference,
@@ -34,8 +34,6 @@ const TextInputRoot = forwardRef<HTMLInputElement, TextInputProperties>(
                 focusInput();
             }
         }, [focusInput]);
-
-        const isDisabled = isTruthy(properties.disabled);
 
         const [focused, setFocused] = useState(false);
         const { isMouseOver, handleMouseOut, handleMouseOver } = useTextInput({
@@ -67,8 +65,8 @@ const TextInputRoot = forwardRef<HTMLInputElement, TextInputProperties>(
                 onMouseOut={handleMouseOut}
                 className={cn(
                     "relative flex h-12 items-center space-x-3 rounded-xl border px-4 transition",
-                    { "cursor-not-allowed": isDisabled },
-                    textInputDynamicClassnames({ hasError, isFocused: focused, isMouseOver, isDisabled }),
+                    { "cursor-not-allowed": disabled },
+                    textInputDynamicClassnames({ hasError, isFocused: focused, isMouseOver, isDisabled: disabled }),
                     wrapperClassName,
                     "dark:bg-theme-dark-900",
                 )}

--- a/resources/js/Components/Navbar/MobileMenu.tsx
+++ b/resources/js/Components/Navbar/MobileMenu.tsx
@@ -14,7 +14,6 @@ import { useEnvironmentContext } from "@/Contexts/EnvironmentContext";
 import { useTransactionSliderContext } from "@/Contexts/TransactionSliderContext";
 import { FormatFiat } from "@/Utils/Currency";
 import { formatAddress } from "@/Utils/format-address";
-import { isTruthy } from "@/Utils/is-truthy";
 import { TruncateMiddle } from "@/Utils/TruncateMiddle";
 
 interface Properties {
@@ -34,7 +33,7 @@ export const MobileMenu = ({
 }: Properties): JSX.Element => {
     const { t } = useTranslation();
 
-    const isAuthenticated = isTruthy(wallet);
+    const isAuthenticated = wallet !== null;
 
     const [isMenuOpen, setMenuOpen] = useState(false);
 

--- a/resources/js/Components/PortfolioBreakdown/Hooks/usePriceChart.ts
+++ b/resources/js/Components/PortfolioBreakdown/Hooks/usePriceChart.ts
@@ -1,7 +1,6 @@
 import { last } from "@ardenthq/sdk-helpers";
 import { type Chart, type ChartDataset, type Point } from "chart.js";
 import { determineMinMaxDataValues } from "@/Components/Graphs/LineChart";
-import { isTruthy } from "@/Utils/is-truthy";
 
 interface UpdatePriceDataProperties {
     chart?: Chart<"line">;
@@ -11,7 +10,13 @@ interface UpdatePriceDataProperties {
     datasets: Array<ChartDataset<"line", Array<number | Point | null>>>;
 }
 
-const updateChartData = ({ chart, labels, values, isPlaceholder, datasets }: UpdatePriceDataProperties): void => {
+const updateChartData = ({
+    chart,
+    labels,
+    values,
+    isPlaceholder = false,
+    datasets,
+}: UpdatePriceDataProperties): void => {
     if (chart === undefined) {
         return;
     }
@@ -20,7 +25,7 @@ const updateChartData = ({ chart, labels, values, isPlaceholder, datasets }: Upd
 
     const isPositive: boolean = values[0] < last(values);
 
-    if (isTruthy(isPlaceholder)) {
+    if (isPlaceholder) {
         chart.data.datasets[0].borderColor = "rgba(196, 200, 207, 1)";
     } else if (isPositive) {
         chart.data.datasets[0].borderColor = "rgba(40, 149, 72, 1)";

--- a/resources/js/Components/PortfolioBreakdown/Hooks/usePriceChart.ts
+++ b/resources/js/Components/PortfolioBreakdown/Hooks/usePriceChart.ts
@@ -1,6 +1,7 @@
 import { last } from "@ardenthq/sdk-helpers";
 import { type Chart, type ChartDataset, type Point } from "chart.js";
 import { determineMinMaxDataValues } from "@/Components/Graphs/LineChart";
+import { isTruthy } from "@/Utils/is-truthy";
 
 interface UpdatePriceDataProperties {
     chart?: Chart<"line">;
@@ -10,13 +11,7 @@ interface UpdatePriceDataProperties {
     datasets: Array<ChartDataset<"line", Array<number | Point | null>>>;
 }
 
-const updateChartData = ({
-    chart,
-    labels,
-    values,
-    isPlaceholder = false,
-    datasets,
-}: UpdatePriceDataProperties): void => {
+const updateChartData = ({ chart, labels, values, isPlaceholder, datasets }: UpdatePriceDataProperties): void => {
     if (chart === undefined) {
         return;
     }
@@ -25,7 +20,7 @@ const updateChartData = ({
 
     const isPositive: boolean = values[0] < last(values);
 
-    if (isPlaceholder) {
+    if (isTruthy(isPlaceholder)) {
         chart.data.datasets[0].borderColor = "rgba(196, 200, 207, 1)";
     } else if (isPositive) {
         chart.data.datasets[0].borderColor = "rgba(40, 149, 72, 1)";

--- a/resources/js/Components/Skeleton/Skeleton.tsx
+++ b/resources/js/Components/Skeleton/Skeleton.tsx
@@ -21,7 +21,7 @@ export const Skeleton = ({
         containerTestId="Skeleton"
         circle={isCircle}
         style={{ width, height }}
-        className={twMerge("z-0 dark:bg-theme-dark-800", "rounded-lg", className)}
+        className={twMerge("z-0 dark:bg-theme-dark-800", !isCircle && "rounded-lg", className)}
         duration={1.3}
         containerClassName="flex w-auto max-w-full items-center leading-none h-full"
     />

--- a/resources/js/Components/Skeleton/Skeleton.tsx
+++ b/resources/js/Components/Skeleton/Skeleton.tsx
@@ -1,22 +1,27 @@
 import SkeletonReact from "react-loading-skeleton";
 import { twMerge } from "tailwind-merge";
-import { isTruthy } from "@/Utils/is-truthy";
 
 interface SkeletonProperties {
     width?: string | number;
     height?: string | number;
     isCircle?: boolean;
-    className?: string;
     animated?: boolean;
+    className?: string;
 }
 
-export const Skeleton = ({ isCircle, width, height, className, animated = true }: SkeletonProperties): JSX.Element => (
+export const Skeleton = ({
+    width,
+    height,
+    animated = true,
+    isCircle = false,
+    className,
+}: SkeletonProperties): JSX.Element => (
     <SkeletonReact
         enableAnimation={animated}
         containerTestId="Skeleton"
         circle={isCircle}
         style={{ width, height }}
-        className={twMerge("z-0 dark:bg-theme-dark-800", !isTruthy(isCircle) ? "rounded-lg" : "", className)}
+        className={twMerge("z-0 dark:bg-theme-dark-800", "rounded-lg", className)}
         duration={1.3}
         containerClassName="flex w-auto max-w-full items-center leading-none h-full"
     />

--- a/resources/js/Pages/Articles/Show.tsx
+++ b/resources/js/Pages/Articles/Show.tsx
@@ -7,7 +7,6 @@ import { Img } from "@/Components/Image";
 import { DefaultLayout } from "@/Layouts/DefaultLayout";
 import { WaveSurferPlayer } from "@/Pages/Articles/Components/WaveSurferPlayer";
 import { ArticlesScroll } from "@/Pages/Collections/Components/Articles/ArticlesScroll";
-import { isTruthy } from "@/Utils/is-truthy";
 import { tp } from "@/Utils/TranslatePlural";
 
 interface Properties {
@@ -45,7 +44,7 @@ const ArticlesShow = ({ article, popularArticles }: Properties): JSX.Element => 
                                 />
                             </div>
                             <div className="w-full">
-                                {isTruthy(article.audioSrc) && (
+                                {article.audioSrc !== null && (
                                     <div className="mb-4 border-theme-secondary-300 dark:border-theme-dark-700 sm:border-b sm:pb-4">
                                         <WaveSurferPlayer url={article.audioSrc} />
                                     </div>

--- a/resources/js/Utils/assertions.ts
+++ b/resources/js/Utils/assertions.ts
@@ -1,5 +1,4 @@
 import { AssertionError } from "assert";
-import { isTruthy } from "@/Utils/is-truthy";
 
 // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
 export function assertUser(user?: App.Data.UserData | null): asserts user is App.Data.UserData {
@@ -12,7 +11,7 @@ export function assertUser(user?: App.Data.UserData | null): asserts user is App
 
 // eslint-disable-next-line prefer-arrow/prefer-arrow-functions
 export function assertWallet(wallet?: App.Data.Wallet.WalletData | null): asserts wallet is App.Data.Wallet.WalletData {
-    if (!isTruthy<App.Data.Wallet.WalletData>(wallet)) {
+    if (wallet === undefined || wallet === null) {
         throw new AssertionError({
             message: `Expected 'wallet' to be App.Data.Wallet.WalletData, but received ${String(wallet)}`,
         });


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/86drj8rbd

There are some places in React where we have some value be either some object or `null`. We can avoid calls to `isTruthy` in these situations as it's simple enough to check whether some value is `null` or `undefined`.

Also, if some component prop is an optional boolean, we can default to `false`, such as in the `TextInput` component, to avoid this prop being possibly `undefined`.

For example:

```tsx
interface Props {
    isDisabled?: boolean;
}

function SomeComponent({ isDisabled = false }: Props) {
    // isDisabled is now always boolean and doesn't need `isTruthy` call
}
```

Just uses more TypeScript to make a nicer developer experience.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
