### PR TITLE
fix: prevent extra networks from being created while seeding

### DIFF
--- a/database/seeders/CollectionFloorPriceHistorySeeder.php
+++ b/database/seeders/CollectionFloorPriceHistorySeeder.php
@@ -24,6 +24,7 @@ class CollectionFloorPriceHistorySeeder extends Seeder
 
             return collect(range(0, $totalEntries))->map(fn ($index) => FloorPriceHistory::factory()->raw([
                 'collection_id' => $collection->id,
+                'token_id' => $collection->floor_price_token_id,
             ]))->sortBy('retrieved_at')->toArray();
         })->toArray();
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/86drtcq5v

If you run `composer db:live` and open the "filter" button on the My Collections page, you'll see a bunch of networks generated. The problem was that when we use `FloorPriceHistory` factory, we'll automatically create a new token for each floor price entry, which will create a new network. We can reuse that token from the collection.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
