### PR TITLE
fix: divison by zero when there is no yesterday's floor price

### DIFF
--- a/app/Models/Traits/HasFloorPriceHistory.php
+++ b/app/Models/Traits/HasFloorPriceHistory.php
@@ -66,6 +66,10 @@ trait HasFloorPriceHistory
             $yesterday->count(), scale: 2, roundingMode: RoundingMode::HALF_UP
         );
 
+        if ($averageYesterday->isZero()) {
+            return null;
+        }
+
         return $averageToday->minus($averageYesterday)
                         ->dividedBy($averageYesterday, scale: 2, roundingMode: RoundingMode::HALF_UP)
                         ->multipliedBy(100)

--- a/tests/App/Models/CollectionTest.php
+++ b/tests/App/Models/CollectionTest.php
@@ -1599,3 +1599,21 @@ it('can get the change in floor price over the last 24 hours', function () {
 
     expect($collection->load('floorPriceHistory')->floorPriceChange())->toBe(20.0);
 });
+
+it("can handle divison by zero if yesterday's floor price is 0", function () {
+    $collection = Collection::factory()->create();
+
+    FloorPriceHistory::factory()->create([
+        'collection_id' => $collection->id,
+        'floor_price' => '0',
+        'retrieved_at' => now()->subDays(1),
+    ]);
+
+    FloorPriceHistory::factory()->create([
+        'collection_id' => $collection->id,
+        'floor_price' => '6',
+        'retrieved_at' => now(),
+    ]);
+
+    expect($collection->load('floorPriceHistory')->floorPriceChange())->toBeNull();
+});


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/86drvxaue

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] I added a storybook entry for the component that was added _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
